### PR TITLE
Add MIT license and update build info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ vov/raw_logs/
 __pycache__/
 *.pyc
 
+
+rust-core/target/
+go-p2p/bin/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 The KAIRO Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,25 @@ git submodule update --remote protocols/kairo-client
 
 AI-TCP uses the interface from `protocols/kairo-client` to send commands to
 and receive responses from the KAIRO server.
+
+## Rust Core and Go P2P Components
+
+This repository also contains optional Rust and Go implementations.
+
+To build the Rust core:
+
+```bash
+cd rust-core
+cargo build --release
+```
+
+Artifacts will be placed in `rust-core/target/`.
+
+To build the Go P2P node:
+
+```bash
+cd go-p2p
+go build -o bin/p2p ./...
+```
+
+The executable will be written to `go-p2p/bin/`.


### PR DESCRIPTION
## Summary
- add the MIT License
- document Rust and Go components in README
- ignore build artifacts for Rust and Go

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614d0ad71c8333ab035f98e8f00e94