### PR TITLE
Add rust-core tests for key rotation and HMAC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vov/raw_logs/
 __pycache__/
 *.pyc
 
+rust-core/target/

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono = "0.4"
+hmac = "0.12"
+sha2 = "0.10"
+rand = "0.8"

--- a/rust-core/src/lib.rs
+++ b/rust-core/src/lib.rs
@@ -1,0 +1,51 @@
+use chrono::{DateTime, Duration, Utc};
+use hmac::{Hmac, Mac};
+use rand::{rngs::OsRng, RngCore};
+use sha2::Sha256;
+
+pub mod signature;
+
+pub struct LogRecorder {
+    key: [u8; 32],
+    key_start: DateTime<Utc>,
+}
+
+impl LogRecorder {
+    pub fn new() -> Self {
+        let mut key = [0u8; 32];
+        OsRng.fill_bytes(&mut key);
+        Self {
+            key,
+            key_start: Utc::now(),
+        }
+    }
+
+    fn rotate_key_if_needed(&mut self) {
+        if Utc::now() - self.key_start > Duration::hours(24) {
+            OsRng.fill_bytes(&mut self.key);
+            self.key_start = Utc::now();
+        }
+    }
+
+    pub fn sign(&mut self, data: &[u8]) -> Vec<u8> {
+        self.rotate_key_if_needed();
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.key)
+            .expect("HMAC can take key of any size");
+        mac.update(data);
+        mac.finalize().into_bytes().to_vec()
+    }
+
+    pub fn key(&self) -> &[u8; 32] {
+        &self.key
+    }
+
+    #[cfg(test)]
+    pub fn set_key_start(&mut self, time: DateTime<Utc>) {
+        self.key_start = time;
+    }
+
+    #[cfg(test)]
+    pub fn key_start(&self) -> DateTime<Utc> {
+        self.key_start
+    }
+}

--- a/rust-core/src/signature.rs
+++ b/rust-core/src/signature.rs
@@ -1,0 +1,14 @@
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+pub fn sign(data: &[u8], key: &[u8]) -> Vec<u8> {
+    let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("HMAC can take key of any size");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+pub fn verify(data: &[u8], key: &[u8], signature: &[u8]) -> bool {
+    let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("HMAC can take key of any size");
+    mac.update(data);
+    mac.verify_slice(signature).is_ok()
+}

--- a/rust-core/tests/key_rotation_test.rs
+++ b/rust-core/tests/key_rotation_test.rs
@@ -1,0 +1,13 @@
+use chrono::{Duration, Utc};
+use rust_core::LogRecorder;
+
+#[test]
+fn rotates_key_after_24_hours() {
+    let mut logger = LogRecorder::new();
+    let first_key = logger.key().clone();
+    logger.set_key_start(Utc::now() - Duration::hours(25));
+    // call sign to trigger rotation
+    logger.sign(b"test");
+    assert_ne!(logger.key(), &first_key);
+    assert!(logger.key_start() > Utc::now() - Duration::minutes(1));
+}

--- a/rust-core/tests/signature_verification_test.rs
+++ b/rust-core/tests/signature_verification_test.rs
@@ -1,0 +1,11 @@
+use rust_core::signature::{sign, verify};
+
+#[test]
+fn verifies_valid_signature() {
+    let key = b"supersecret";
+    let message = b"hello";
+    let sig = sign(message, key);
+    assert!(verify(message, key, &sig));
+    let wrong_sig = sign(b"bad", key);
+    assert!(!verify(message, key, &wrong_sig));
+}


### PR DESCRIPTION
## Summary
- create a new `rust-core` crate
- implement key rotation and signature helpers
- add key rotation and signature verification tests
- ignore Cargo build artifacts

## Testing
- `pytest -q`
- `cargo test` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_68614d09d32c8333b2c1a71277429e82