### PR TITLE
Add Go P2P module

### DIFF
--- a/go-p2p/cmd/main.go
+++ b/go-p2p/cmd/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+    "context"
+    "log"
+    "net/http"
+
+    "github.com/elementary-particles-Man/KAIRO/go-p2p/pkg"
+)
+
+func main() {
+    ctx := context.Background()
+    mgr, err := pkg.NewManager(ctx)
+    if err != nil {
+        log.Fatalf("failed to create p2p manager: %v", err)
+    }
+    defer mgr.Close()
+
+    handler := pkg.NewAPIHandler(mgr)
+    srv := &http.Server{Addr: ":8080", Handler: handler}
+    log.Println("HTTP API listening on :8080")
+    if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+        log.Fatalf("server error: %v", err)
+    }
+}

--- a/go-p2p/go.mod
+++ b/go-p2p/go.mod
@@ -1,0 +1,3 @@
+module github.com/elementary-particles-Man/KAIRO/go-p2p
+
+go 1.24.3

--- a/go-p2p/pkg/handlers.go
+++ b/go-p2p/pkg/handlers.go
@@ -1,0 +1,25 @@
+package pkg
+
+import (
+    "encoding/json"
+    "net/http"
+)
+
+// APIHandler exposes HTTP endpoints to interact with the P2P manager.
+type APIHandler struct{
+    M *Manager
+}
+
+func NewAPIHandler(m *Manager) *APIHandler {
+    return &APIHandler{M: m}
+}
+
+func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    switch r.URL.Path {
+    case "/force_disconnect":
+        h.M.ForceDisconnect()
+        json.NewEncoder(w).Encode(map[string]bool{"disconnected": true})
+    default:
+        w.WriteHeader(http.StatusNotFound)
+    }
+}

--- a/go-p2p/pkg/p2p_manager.go
+++ b/go-p2p/pkg/p2p_manager.go
@@ -1,0 +1,33 @@
+package pkg
+
+import (
+    "context"
+
+    libp2p "github.com/libp2p/go-libp2p"
+    "github.com/libp2p/go-libp2p/core/host"
+)
+
+// Manager holds the libp2p host instance.
+type Manager struct {
+    ctx  context.Context
+    Host host.Host
+}
+
+// NewManager creates a new libp2p host listening on any available port.
+func NewManager(ctx context.Context) (*Manager, error) {
+    h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
+    if err != nil {
+        return nil, err
+    }
+    return &Manager{ctx: ctx, Host: h}, nil
+}
+
+// Close shuts down the libp2p host.
+func (m *Manager) Close() error {
+    return m.Host.Close()
+}
+
+// ForceDisconnect calls into rust-core via FFI to trigger a shutdown.
+func (m *Manager) ForceDisconnect() {
+    forceDisconnect()
+}

--- a/go-p2p/pkg/rust_bridge.go
+++ b/go-p2p/pkg/rust_bridge.go
@@ -1,0 +1,12 @@
+package pkg
+
+/*
+#cgo LDFLAGS: -L../../rust-core/target/release -lrust_core
+void force_disconnect();
+*/
+import "C"
+
+// forceDisconnect invokes the Rust core library function.
+func forceDisconnect() {
+    C.force_disconnect()
+}


### PR DESCRIPTION
## Summary
- add `go-p2p` module initialized with Go modules
- implement p2p manager using go-libp2p and expose HTTP API
- provide FFI bridge to Rust `force_disconnect`

## Testing
- `pytest -q`
- `go mod tidy` *(fails: proxy access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68614d08187c8333a0e7c749e7380eb5