### PR TITLE
Add developer-facing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ The executable will be written to `go-p2p/bin/`.
 
 ---
 
+### Developer-facing Errors
+
+Client libraries raise structured exceptions with a `transaction_id` so that
+failures can be correlated with VoV logs. The exposed errors are:
+
+- `AuthenticationError`
+- `TimeoutError`
+- `ConnectionLostError`
+
+Cryptographic issues are logged via `LogRecorder.log_error` but are not exposed
+directly to client code.
+
+---
+
 ## Security Note
 
 All AI-TCP packets handled by KAIRO are designed to be fully binary using **FlatBuffers**,

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,13 @@
+from .errors import (
+    AuthenticationError,
+    TimeoutError,
+    ConnectionLostError,
+    KairoError,
+)
+
+__all__ = [
+    "KairoError",
+    "AuthenticationError",
+    "TimeoutError",
+    "ConnectionLostError",
+]

--- a/src/errors.py
+++ b/src/errors.py
@@ -1,0 +1,30 @@
+class KairoError(Exception):
+    """Base class for KAIRO developer-facing errors."""
+
+    def __init__(self, transaction_id: str, message: str) -> None:
+        super().__init__(message)
+        self.transaction_id = transaction_id
+        self.message = message
+
+    def as_dict(self) -> dict:
+        return {
+            "transaction_id": self.transaction_id,
+            "error": self.__class__.__name__,
+            "message": self.message,
+        }
+
+
+class AuthenticationError(KairoError):
+    """Raised when authentication fails."""
+
+
+class TimeoutError(KairoError):
+    """Raised when an operation times out."""
+
+
+class ConnectionLostError(KairoError):
+    """Raised when the connection is lost."""
+
+
+class _CryptographicError(KairoError):
+    """Internal error for cryptographic failures."""

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.errors import AuthenticationError, TimeoutError, ConnectionLostError
+
+
+def test_error_contains_transaction_id():
+    err = AuthenticationError("tx1", "bad creds")
+    assert err.transaction_id == "tx1"
+    assert "bad creds" in str(err)
+
+
+def test_as_dict():
+    err = TimeoutError("abc", "timeout")
+    info = err.as_dict()
+    assert info["transaction_id"] == "abc"
+    assert info["error"] == "TimeoutError"
+    assert info["message"] == "timeout"
+
+
+def test_connection_lost_error():
+    err = ConnectionLostError("xyz", "lost")
+    assert isinstance(err, ConnectionLostError)
+    assert err.transaction_id == "xyz"
+

--- a/vov/README.md
+++ b/vov/README.md
@@ -13,5 +13,9 @@ Each log entry follows the schema:
 | `signature` | HMAC signature of the log payload |
 | `deny_flag` | Boolean indicating if access was denied |
 
+Failure logs created via `LogRecorder.log_error` additionally include the
+fields `transaction_id` and `error_type` so that issues can be traced while the
+VoV layer records the corresponding `uuid`, `timestamp` and `hash`.
+
 Logs are appended to ``vov/log.jsonl`` and the signing key rotates every 24
 hours. Example logs can be found in ``vov/example_log.jsonl``.


### PR DESCRIPTION
## Summary
- define `AuthenticationError`, `TimeoutError`, and `ConnectionLostError`
- export developer-facing errors in `src.__init__`
- extend `LogRecorder` with `ErrorEntry` and `log_error`
- mention failure logging details in `vov/README.md`
- document the developer-facing errors in the main `README.md`
- test new error classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861575bf65883338b129a580969ee7f