### PR TITLE
Add coordination node skeleton

### DIFF
--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -14,3 +14,6 @@ ed25519-dalek = "1.0" # ed25519-dalek v1系はrand_core 0.5に依存
 rand = "0.7"          # ed25519-dalek v1系に合わせてrand 0.7系を指定
 hmac = "0.12"
 sha2 = "0.10"
+warp = "0.3"
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/rust-core/src/coordination/api.rs
+++ b/rust-core/src/coordination/api.rs
@@ -1,0 +1,55 @@
+// D:\dev\KAIRO\rust-core\src\coordination\api.rs
+use warp::Filter;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use super::node_manager::{NodeManager, Node};
+
+#[derive(Deserialize)]
+struct RegisterRequest {
+    id: String,
+    public_key: Vec<u8>,
+}
+
+#[derive(Serialize)]
+struct RegisterResponse {
+    virtual_ip: String,
+}
+
+pub fn register_route(manager: Arc<NodeManager>) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::post()
+        .and(warp::path("register"))
+        .and(warp::body::json())
+        .and(with_manager(manager))
+        .and_then(handle_register)
+}
+
+pub fn peers_route(manager: Arc<NodeManager>) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::get()
+        .and(warp::path("peers"))
+        .and(warp::query::<PeerQuery>())
+        .and(with_manager(manager))
+        .and_then(handle_peers)
+}
+
+#[derive(Deserialize)]
+struct PeerQuery {
+    id: String,
+}
+
+fn with_manager(manager: Arc<NodeManager>) -> impl Filter<Extract = (Arc<NodeManager>,), Error = std::convert::Infallible> + Clone {
+    warp::any().map(move || manager.clone())
+}
+
+async fn handle_register(req: RegisterRequest, manager: Arc<NodeManager>) -> Result<impl warp::Reply, warp::Rejection> {
+    // TODO: VoV logging of registration event
+    let ip = manager.register_node(req.id, req.public_key);
+    let ip = ip.unwrap_or_default();
+    Ok(warp::reply::json(&RegisterResponse { virtual_ip: ip }))
+}
+
+async fn handle_peers(query: PeerQuery, manager: Arc<NodeManager>) -> Result<impl warp::Reply, warp::Rejection> {
+    // TODO: authentication and VoV logging
+    let peers: Vec<Node> = manager.get_peers(&query.id);
+    Ok(warp::reply::json(&peers))
+}

--- a/rust-core/src/coordination/mod.rs
+++ b/rust-core/src/coordination/mod.rs
@@ -1,0 +1,3 @@
+// D:\dev\KAIRO\rust-core\src\coordination\mod.rs
+pub mod node_manager;
+pub mod api;

--- a/rust-core/src/coordination/node_manager.rs
+++ b/rust-core/src/coordination/node_manager.rs
@@ -1,0 +1,32 @@
+// D:\dev\KAIRO\rust-core\src\coordination\node_manager.rs
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+pub struct Node {
+    pub id: String, // 128-bit Unique ID represented as hex string
+    pub public_key: Vec<u8>,
+    pub virtual_ip: String,
+}
+
+pub struct NodeManager {
+    pub nodes: Arc<Mutex<HashMap<String, Node>>>,
+}
+
+impl NodeManager {
+    pub fn new() -> Self {
+        Self {
+            nodes: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    // TODO: implement node registration with key exchange and IP assignment
+    pub fn register_node(&self, _id: String, _public_key: Vec<u8>) -> Option<String> {
+        todo!("Register node and return assigned virtual IP");
+    }
+
+    // TODO: return list of peers (public_key and virtual_ip) for authenticated node
+    pub fn get_peers(&self, _id: &str) -> Vec<Node> {
+        todo!("Return peer list for authenticated node");
+    }
+}

--- a/rust-core/src/lib.rs
+++ b/rust-core/src/lib.rs
@@ -4,3 +4,4 @@ pub mod error;
 pub mod packet_parser;
 pub mod signature;
 pub mod log_recorder;
+pub mod coordination;


### PR DESCRIPTION
## Summary
- implement stub coordination module with node manager and API endpoints
- expose the coordination module in the library
- add warp, tokio, and serde dependencies for the HTTP interface

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686242d894408333b97f77542790b2af