### PR TITLE
Implement Coordination Node skeleton

### DIFF
--- a/AI-TCP/core/kairo_coord_node/Cargo.toml
+++ b/AI-TCP/core/kairo_coord_node/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kairo_coord_node"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+uuid = { version = "1", features = ["v4"] }
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/AI-TCP/core/kairo_coord_node/src/lib.rs
+++ b/AI-TCP/core/kairo_coord_node/src/lib.rs
@@ -1,0 +1,83 @@
+use chrono::{Local, TimeZone};
+use serde::Serialize;
+use std::{collections::HashMap, fs::OpenOptions, io::Write, net::Ipv4Addr};
+use uuid::Uuid;
+
+#[derive(Clone, Debug)]
+pub struct Peer {
+    pub uuid: Uuid,
+    pub mesh_ip: Ipv4Addr,
+    pub public_key: String,
+}
+
+pub struct CoordinationNode {
+    pub node_id: Uuid,
+    peers: HashMap<Uuid, Peer>,
+}
+
+impl CoordinationNode {
+    pub fn new_from_env() -> Self {
+        let node_id = std::env::var("KAIRO_NODE_ID")
+            .ok()
+            .and_then(|v| Uuid::parse_str(&v).ok())
+            .unwrap_or_else(Uuid::new_v4);
+        Self { node_id, peers: HashMap::new() }
+    }
+
+    pub fn add_peer(&mut self, public_key: String) -> Peer {
+        let uuid = Uuid::new_v4();
+        let ip_suffix = (self.peers.len() + 1) as u8;
+        let mesh_ip = Ipv4Addr::new(100, 64, 0, ip_suffix);
+        let peer = Peer { uuid, mesh_ip, public_key };
+        self.peers.insert(uuid, peer.clone());
+        self.log_event("peer_added", Some(uuid), Some(mesh_ip));
+        peer
+    }
+
+    pub fn remove_peer(&mut self, uuid: &Uuid) -> bool {
+        if let Some(peer) = self.peers.remove(uuid) {
+            self.log_event("peer_removed", Some(peer.uuid), Some(peer.mesh_ip));
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn get_peers(&self) -> &HashMap<Uuid, Peer> {
+        &self.peers
+    }
+
+    pub fn log_event(&self, event: &str, peer: Option<Uuid>, ip: Option<Ipv4Addr>) {
+        let dir = std::path::Path::new("logs");
+        std::fs::create_dir_all(dir).ok();
+        let file_name = format!(
+            "CoordinationNode_{}.log",
+            Local::now().format("%Y%m%d")
+        );
+        let path = dir.join(file_name);
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .expect("open log file");
+        let entry = EventLog {
+            node_id: self.node_id.to_string(),
+            event: event.to_string(),
+            peer_uuid: peer.map(|p| p.to_string()),
+            mesh_ip: ip.map(|p| p.to_string()),
+            timestamp: Local.timestamp_millis(Local::now().timestamp_millis()).to_rfc3339(),
+        };
+        let line = serde_json::to_string(&entry).unwrap();
+        let _ = writeln!(file, "{}", line);
+    }
+}
+
+#[derive(Serialize)]
+struct EventLog {
+    node_id: String,
+    timestamp: String,
+    event: String,
+    peer_uuid: Option<String>,
+    mesh_ip: Option<String>,
+}
+

--- a/AI-TCP/core/kairo_coord_node/src/main.rs
+++ b/AI-TCP/core/kairo_coord_node/src/main.rs
@@ -1,0 +1,8 @@
+use kairo_coord_node::CoordinationNode;
+
+fn main() {
+    let mut node = CoordinationNode::new_from_env();
+    node.log_event("node_started", None, None);
+    println!("Coordination Node {} started", node.node_id);
+    // Placeholder for future REST/gRPC API
+}

--- a/AI-TCP/core/kairo_coord_node/tests/node_tests.rs
+++ b/AI-TCP/core/kairo_coord_node/tests/node_tests.rs
@@ -1,0 +1,18 @@
+use kairo_coord_node::CoordinationNode;
+use uuid::Uuid;
+
+#[test]
+fn test_uuid_generation() {
+    std::env::remove_var("KAIRO_NODE_ID");
+    let node = CoordinationNode::new_from_env();
+    assert!(Uuid::parse_str(&node.node_id.to_string()).is_ok());
+}
+
+#[test]
+fn test_peer_add_remove() {
+    let mut node = CoordinationNode::new_from_env();
+    let peer = node.add_peer("testkey".to_string());
+    assert_eq!(node.get_peers().len(), 1);
+    assert!(node.remove_peer(&peer.uuid));
+    assert_eq!(node.get_peers().len(), 0);
+}

--- a/README.md
+++ b/README.md
@@ -147,3 +147,18 @@ which records immutable UUIDs, timestamps, and integrity hashes.
 
 ## OpenAI API Transition
 See `docs/openai_api_compatibility_plan.md` for the phased deprecation plan and `cli-migrate` helper.
+
+## Coordination Node Skeleton (AITCP-CORE-001)
+The directory `AI-TCP/core/kairo_coord_node/` contains a Rust prototype of the self-governing Coordination Node. It manages peer public keys and assigns virtual IPs in the `100.64.0.0/16` range without relying on external services.
+
+### UUID, Mesh IP and Key Management Flow
+1. On startup, the node uses `KAIRO_NODE_ID` if provided or generates a 128-bit UUID.
+2. Each added peer receives a unique UUID and a Mesh IP such as `100.64.0.x`.
+3. All creation and removal events are logged under `logs/CoordinationNode_YYYYMMDD.log` with JST/ISO8601 timestamps.
+4. Placeholder APIs for future REST/gRPC configuration are defined in the crate.
+
+Run the node with:
+```bash
+cd AI-TCP/core/kairo_coord_node
+cargo run
+```


### PR DESCRIPTION
## Summary
- set up `kairo_coord_node` Rust crate under `AI-TCP/core`
- implement UUID-based node and peer management with log output
- add skeleton CLI entrypoint
- document usage and flow in README
- keep logs directory tracked

## Testing
- `pytest -q`
- `cargo test -q` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686244affc548333b23dd10a771c3cba