### PR TITLE
Add coordination node dependencies

### DIFF
--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -10,6 +10,8 @@ flatbuffers = "23.5.26"
 ed25519-dalek = "1.0.1"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+warp = "0.3"
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
## Summary
- add warp and tokio to `rust-core` dependencies

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6862d311a8c88333aa116383966e4c30