### PR TITLE
Implement node registration

### DIFF
--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -12,6 +12,7 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 warp = "0.3"
 tokio = { version = "1", features = ["full"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/rust-core/src/coordination/api.rs
+++ b/rust-core/src/coordination/api.rs
@@ -7,7 +7,6 @@ use super::node_manager::{NodeManager, Node};
 
 #[derive(Deserialize)]
 struct RegisterRequest {
-    id: String,
     public_key: Vec<u8>,
 }
 
@@ -43,8 +42,8 @@ fn with_manager(manager: Arc<NodeManager>) -> impl Filter<Extract = (Arc<NodeMan
 
 async fn handle_register(req: RegisterRequest, manager: Arc<NodeManager>) -> Result<impl warp::Reply, warp::Rejection> {
     // TODO: VoV logging of registration event
-    let ip = manager.register_node(req.id, req.public_key);
-    let ip = ip.unwrap_or_default();
+    let node = manager.register_node(req.public_key);
+    let ip = node.map(|n| n.virtual_ip).unwrap_or_default();
     Ok(warp::reply::json(&RegisterResponse { virtual_ip: ip }))
 }
 

--- a/rust-core/src/coordination/node_manager.rs
+++ b/rust-core/src/coordination/node_manager.rs
@@ -1,6 +1,7 @@
 // D:\dev\KAIRO\rust-core\src\coordination\node_manager.rs
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use uuid::Uuid;
 
 #[derive(Clone, serde::Serialize)]
 pub struct Node {
@@ -20,9 +21,37 @@ impl NodeManager {
         }
     }
 
-    // TODO: implement node registration with key exchange and IP assignment
-    pub fn register_node(&self, _id: String, _public_key: Vec<u8>) -> Option<String> {
-        todo!("Register node and return assigned virtual IP");
+    /// Register a new node and assign a virtual IP within 100.64.0.0/10.
+    /// Returns the created [`Node`] on success.
+    pub fn register_node(&self, public_key: Vec<u8>) -> Option<Node> {
+        let id = Uuid::new_v4().as_simple().to_string();
+
+        let mut nodes = self.nodes.lock().ok()?;
+
+        // Allocate a virtual IP starting from 100.64.0.1
+        let mut suffix: u16 = 1;
+        loop {
+            let third = (suffix / 256) as u8;
+            let fourth = (suffix % 256) as u8;
+            let ip = format!("100.64.{}.{}", third, fourth);
+            if !nodes.values().any(|n| n.virtual_ip == ip) {
+                let node = Node {
+                    id: id.clone(),
+                    public_key,
+                    virtual_ip: ip.clone(),
+                };
+                nodes.insert(id.clone(), node.clone());
+                return Some(node);
+            }
+
+            // Prevent infinite loops if IP space is exhausted
+            if suffix == u16::MAX {
+                break;
+            }
+            suffix += 1;
+        }
+
+        None
     }
 
     // TODO: return list of peers (public_key and virtual_ip) for authenticated node

--- a/rust-core/tests/coordination_test.rs
+++ b/rust-core/tests/coordination_test.rs
@@ -1,0 +1,16 @@
+use rust_core::coordination::node_manager::NodeManager;
+
+#[test]
+fn test_register_node() {
+    let manager = NodeManager::new();
+    let pk1 = vec![1u8, 2, 3];
+    let node1 = manager.register_node(pk1.clone()).expect("registration failed");
+    assert_eq!(node1.public_key, pk1);
+    assert_eq!(node1.virtual_ip, "100.64.0.1");
+
+    let pk2 = vec![4u8, 5, 6];
+    let node2 = manager.register_node(pk2.clone()).expect("registration failed");
+    assert_eq!(node2.public_key, pk2);
+    assert_eq!(node2.virtual_ip, "100.64.0.2");
+    assert_ne!(node1.id, node2.id);
+}


### PR DESCRIPTION
## Summary
- implement `NodeManager::register_node` to allocate an ID and IP
- expose the registration via the API
- depend on the `uuid` crate
- add `coordination_test.rs` covering node registration

## Testing
- `cargo build --release` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686a5382848c8333aa10b74a07400290