### PR TITLE
Add FFI export test

### DIFF
--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 criterion = "0.5"
+libloading = "0.7"
 
 [[bench]]
 name = "benchmark_flatbuffers"

--- a/rust-core/src/lib.rs
+++ b/rust-core/src/lib.rs
@@ -37,6 +37,26 @@ pub extern "C" fn add_numbers(a: i32, b: i32) -> i32 {
 }
 
 // ----------------------------
+// ✅ VoVログ検証関数 (dummy implementation)
+// ----------------------------
+
+#[no_mangle]
+pub extern "C" fn validate_vov_log() -> i32 {
+    // In a real implementation this would validate VoV log entries.
+    0
+}
+
+// ----------------------------
+// ✅ 署名生成関数 (dummy implementation)
+// ----------------------------
+
+#[no_mangle]
+pub extern "C" fn generate_signature() -> i32 {
+    // In a real implementation this would return a generated signature.
+    0
+}
+
+// ----------------------------
 // ✅ 必要に応じて内部ロジックをここに置く
 // ----------------------------
 

--- a/rust-core/tests/test_link.rs
+++ b/rust-core/tests/test_link.rs
@@ -1,0 +1,26 @@
+use libloading::Library;
+
+#[test]
+fn test_linkage() {
+    // Determine the library path relative to the workspace root.
+    let lib_path = if cfg!(target_os = "windows") {
+        "../../target/release/rust_core.dll"
+    } else if cfg!(target_os = "macos") {
+        "../../target/release/librust_core.dylib"
+    } else {
+        "../../target/release/librust_core.so"
+    };
+
+    let lib = Library::new(lib_path).expect("load rust_core library");
+    unsafe {
+        let validate: libloading::Symbol<unsafe extern "C" fn() -> i32> =
+            lib.get(b"validate_vov_log\0").expect("validate_vov_log symbol");
+        let result = std::panic::catch_unwind(|| validate());
+        assert!(result.is_ok());
+
+        let sign: libloading::Symbol<unsafe extern "C" fn() -> i32> =
+            lib.get(b"generate_signature\0").expect("generate_signature symbol");
+        let result2 = std::panic::catch_unwind(|| sign());
+        assert!(result2.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary
- add dummy FFI functions `validate_vov_log` and `generate_signature`
- add `libloading` as dev-dependency
- add `test_link.rs` to load `rust_core.dll` and call FFI functions

## Testing
- `pytest -q`
- `cargo test --manifest-path rust-core/Cargo.toml --no-run --offline` *(fails: no matching package named `chrono` found)*

------
https://chatgpt.com/codex/tasks/task_e_686a72af62f08333af515f752d2aca5e