### PR TITLE
Add sample PCAP docs and ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 *.pyc
 rust-core/target/
 go-p2p/bin/
+*.pcap

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,6 @@
+# Sample PCAP
+
+This directory holds example packet captures used for testing or demonstration.
+Only the provided sample trace should be committed to version control. Any
+additional `.pcap` files generated during development should remain untracked.
+


### PR DESCRIPTION
## Summary
- ignore `*.pcap` files
- add `samples/README.md` noting only provided capture should be tracked

## Testing
- `pytest -q`
- `cargo test --manifest-path rust-core/Cargo.toml --quiet` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686a7c970a308333800e0ace9b428ff8