### PR TITLE
Add KAIRO-F Rust PoC and Go pcap node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,3 +2216,14 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "kairof"
+version = "0.1.0"
+dependencies = [
+ "flatbuffers",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rust-core",
+]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,10 @@
 # =============================
 
 [workspace]
-members = [
+members = [ "kairof",
     "rust-core"
 ]
+resolver = "1"
 
 # ✅ ポイント
 # - ルートに共通 dev-dependencies は定義せず

--- a/go-p2p/cmd/pcap_node/main.go
+++ b/go-p2p/cmd/pcap_node/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+    "fmt"
+    "github.com/elementary-particles-Man/KAIRO/go-p2p/pkg"
+    "github.com/google/gopacket"
+    "github.com/google/gopacket/pcap"
+    libp2p "github.com/libp2p/go-libp2p"
+)
+
+func main() {
+    host, err := libp2p.New()
+    if err != nil {
+        fmt.Println("libp2p init failed:", err)
+        return
+    }
+    fmt.Println("Node ID:", host.ID())
+
+    handle, err := pcap.OpenOffline("../../samples/kairof_sample.pcap")
+    if err != nil {
+        fmt.Println("pcap open failed:", err)
+        pkg.LogParseError()
+        return
+    }
+    defer handle.Close()
+
+    source := gopacket.NewPacketSource(handle, handle.LinkType())
+    count := 0
+    for range source.Packets() {
+        count++
+    }
+    fmt.Println("packets read:", count)
+}

--- a/go-p2p/go.mod
+++ b/go-p2p/go.mod
@@ -2,4 +2,8 @@ module github.com/elementary-particles-Man/KAIRO/go-p2p
 
 go 1.24.3
 
-require github.com/google/flatbuffers v25.2.10+incompatible
+require (
+    github.com/google/flatbuffers v25.2.10+incompatible
+    github.com/google/gopacket v1.1.19
+    github.com/libp2p/go-libp2p v0.30.0
+)

--- a/go-p2p/pkg/rust_bridge.go
+++ b/go-p2p/pkg/rust_bridge.go
@@ -3,10 +3,16 @@ package pkg
 /*
 #cgo LDFLAGS: -L../../rust-core/target/release -lrust_core
 void force_disconnect();
+void log_parse_error();
 */
 import "C"
 
 // forceDisconnect invokes the Rust core library function.
 func forceDisconnect() {
     C.force_disconnect()
+}
+
+// LogParseError calls into the Rust library to log parsing failures.
+func LogParseError() {
+    C.log_parse_error()
 }

--- a/kairof/Cargo.toml
+++ b/kairof/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kairof"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+flatbuffers = "25.2.10"
+rand = "0.8"
+rand_core = "0.6"
+rust-core = { path = "../rust-core" }

--- a/kairof/src/generate_pcap.rs
+++ b/kairof/src/generate_pcap.rs
@@ -1,0 +1,14 @@
+use std::fs::File;
+use std::io::Write;
+
+fn main() -> std::io::Result<()> {
+    let data = kairof::build_pcap();
+    let path = std::path::Path::new("samples/kairof_sample.pcap");
+    if let Some(p) = path.parent() {
+        std::fs::create_dir_all(p)?;
+    }
+    let mut file = File::create(path)?;
+    file.write_all(&data)?;
+    println!("PCAP written to {}", path.display());
+    Ok(())
+}

--- a/kairof/src/lib.rs
+++ b/kairof/src/lib.rs
@@ -1,0 +1,63 @@
+use flatbuffers::FlatBufferBuilder;
+use rand::RngCore;
+use rust_core::ai_tcp_packet_generated::aitcp as fb;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Build a single AITcpPacket with the given sequence id.
+pub fn build_packet(seq_id: u64) -> Vec<u8> {
+    let mut builder = FlatBufferBuilder::new();
+
+    let mut ephemeral = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut ephemeral);
+    let ephemeral_vec = builder.create_vector(&ephemeral);
+
+    let mut nonce = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut nonce);
+    let nonce_vec = builder.create_vector(&nonce);
+
+    let seq_bytes = seq_id.to_le_bytes();
+    let seq_vec = builder.create_vector(&seq_bytes);
+
+    let payload_vec = builder.create_vector(&[0u8; 0]);
+    let signature_vec = builder.create_vector(&[0u8; 64]);
+
+    let pkt = fb::AITcpPacket::create(&mut builder, &fb::AITcpPacketArgs {
+        version: 1,
+        ephemeral_key: Some(ephemeral_vec),
+        nonce: Some(nonce_vec),
+        encrypted_sequence_id: Some(seq_vec),
+        encrypted_payload: Some(payload_vec),
+        signature: Some(signature_vec),
+    });
+    builder.finish(pkt, None);
+    builder.finished_data().to_vec()
+}
+
+/// Build a simple PCAP capture containing three packets.
+pub fn build_pcap() -> Vec<u8> {
+    let mut out = Vec::new();
+
+    out.extend(&0xA1B2C3D4u32.to_le_bytes());
+    out.extend(&2u16.to_le_bytes());
+    out.extend(&4u16.to_le_bytes());
+    out.extend(&0u32.to_le_bytes());
+    out.extend(&0u32.to_le_bytes());
+    out.extend(&65535u32.to_le_bytes());
+    out.extend(&101u32.to_le_bytes());
+
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u32;
+
+    for i in 1..=3u32 {
+        let pkt = build_packet(i as u64);
+        out.extend(&(ts + i - 1).to_le_bytes());
+        out.extend(&0u32.to_le_bytes());
+        out.extend(&(pkt.len() as u32).to_le_bytes());
+        out.extend(&(pkt.len() as u32).to_le_bytes());
+        out.extend(&pkt);
+    }
+
+    out
+}

--- a/rust-core/src/lib.rs
+++ b/rust-core/src/lib.rs
@@ -42,6 +42,12 @@ pub extern "C" fn add_numbers(a: i32, b: i32) -> i32 {
     a + b
 }
 
+#[no_mangle]
+pub extern "C" fn log_parse_error() {
+    let err = error::KairoError::PacketParseFailed;
+    eprintln!("Kairo error: {err}");
+}
+
 // ---------- LogRecorder 構造体 ----------
 pub struct LogRecorder {
     key: [u8; 32],

--- a/rust-core/tests/kairof_packet_test.rs
+++ b/rust-core/tests/kairof_packet_test.rs
@@ -1,0 +1,7 @@
+use kairof::build_pcap;
+
+#[test]
+fn test_kairof_build_pcap() {
+    let pcap = build_pcap();
+    assert!(pcap.len() > 0);
+}


### PR DESCRIPTION
## Summary
- generate PCAP in Rust via new `kairof` crate
- export logging of `KairoError::PacketParseFailed`
- minimal Go libp2p node reads the generated PCAP
- added Rust test for PCAP generation
- unify workspace resolver and dependencies

## Testing
- `cargo build --locked` *(fails: failed to download crates index)*
- `cargo test` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_686c26cd63b883338bd9e6a6def722e4