### PR TITLE
[Codex Task] Update schema workflow and add tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+*.sh text eol=lf
+*.rs text eol=lf
+*.yml text eol=lf
+*.ps1 text eol=crlf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install flatc
         run: sudo snap install flatbuffers
-      - name: Generate FlatBuffers for Rust
-        run: flatc --rust -o rust-core/src/ schema/ai_tcp_packet.fbs
-      - name: Generate FlatBuffers for Go
-        run: flatc --go -o go-p2p/pkg/generated/AITCP/ schema/ai_tcp_packet.fbs
+      - name: Generate FlatBuffers
+        run: make generate_schema
       - name: Check for uncommitted changes
         run: |
           git status --porcelain

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ __pycache__/
 
 # PCAP生成物（サンプル以外）
 samples/*.pcap
+samples/
+!samples/README.md
+!samples/*.jsonl
 
 # VSCode/IDE
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+FLATC ?= flatc
+
+.PHONY: generate_schema
+generate_schema:
+$(FLATC) --rust -o rust-core/src/ schema/ai_tcp_packet.fbs
+$(FLATC) --go -o go-p2p/pkg/generated/AITCP/ schema/ai_tcp_packet.fbs
+
+.PHONY: check_schema
+check_schema: generate_schema
+@status=`git status --porcelain`; \
+if [ -n "$$status" ]; then \
+  echo "FlatBuffers generated files are not up-to-date."; \
+  git diff; \
+  exit 1; \
+else \
+  echo "Schema is up-to-date."; \
+fi

--- a/rust-core/src/coordination.rs
+++ b/rust-core/src/coordination.rs
@@ -1,0 +1,11 @@
+pub struct CoordinationNode;
+
+impl CoordinationNode {
+    pub fn init() {
+        println!("Coordination node initialized");
+    }
+
+    pub fn shutdown() {
+        println!("Coordination node shutting down");
+    }
+}

--- a/rust-core/src/lib.rs
+++ b/rust-core/src/lib.rs
@@ -23,7 +23,7 @@ pub mod ai_tcp_packet_generated; // FlatBuffers generated code
 pub mod error;                // Custom error types
 
 // ---------- Coordination Node Skeleton (Optional) ----------
-// pub mod coordination;       // Uncomment when using coordination node
+pub mod coordination;
 
 // ---------- Go連携用エクスポート関数 ----------
 #[no_mangle]

--- a/rust-core/src/log_recorder.rs
+++ b/rust-core/src/log_recorder.rs
@@ -1,7 +1,8 @@
 // D:\dev\KAIRO\rust-core\src\log_recorder.rs
-use hmac::Hmac;
+use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use chrono::{DateTime, Utc};
+use rand::{rngs::OsRng, RngCore};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -17,9 +18,28 @@ impl LogRecorder {
             key_creation_time: Utc::now(),
         }
     }
-    // ダミーのキーローテーション関数
-    pub fn rotate_key_if_needed(&mut self) {
-        self.key = vec![0; 32]; // 新しいキーに更新
-        self.key_creation_time = Utc::now();
+    /// Sign arbitrary data with the current HMAC key
+    pub fn sign(&self, data: &[u8]) -> Vec<u8> {
+        let mut mac = HmacSha256::new_from_slice(&self.key).expect("HMAC init");
+        mac.update(data);
+        mac.finalize().into_bytes().to_vec()
     }
-}
+
+    /// Verify the HMAC for the given data
+    pub fn verify(&self, data: &[u8], tag: &[u8]) -> bool {
+        let mut mac = HmacSha256::new_from_slice(&self.key).expect("HMAC init");
+        mac.update(data);
+        mac.verify_slice(tag).is_ok()
+    }
+
+    /// Rotate the signing key
+    pub fn rotate_key_if_needed(&mut self) {
+        self.key_creation_time = Utc::now();
+        let mut new_key = vec![0u8; 32];
+        OsRng.fill_bytes(&mut new_key);
+        self.key = new_key;
+    }
+
+    pub fn key(&self) -> &[u8] {
+        &self.key
+    }}

--- a/rust-core/tests/ephemeral_signature_test.rs
+++ b/rust-core/tests/ephemeral_signature_test.rs
@@ -1,0 +1,14 @@
+use ed25519_dalek::{SigningKey, VerifyingKey, Keypair};
+use rust_core::keygen::ephemeral_key;
+use rust_core::signature::{sign_ed25519, verify_ed25519};
+
+#[test]
+fn ephemeral_key_signature_consistency() {
+    let sk_bytes = ephemeral_key();
+    let signing = SigningKey::from_bytes(&sk_bytes);
+    let verifying = VerifyingKey::from(&signing);
+    let keypair = Keypair{ secret: signing, public: verifying };
+    let msg = b"integration-test";
+    let sig = sign_ed25519(&keypair, msg);
+    assert!(verify_ed25519(&keypair.public, msg, &sig));
+}

--- a/rust-core/tests/log_recorder_test.rs
+++ b/rust-core/tests/log_recorder_test.rs
@@ -1,0 +1,17 @@
+use rust_core::log_recorder::LogRecorder;
+
+#[test]
+fn hmac_rotation_verification() {
+    let initial_key = vec![1u8; 32];
+    let mut recorder = LogRecorder::new(initial_key.clone());
+    let data = b"test-entry";
+
+    let sig1 = recorder.sign(data);
+    assert!(recorder.verify(data, &sig1));
+
+    recorder.rotate_key_if_needed();
+    assert!(!recorder.verify(data, &sig1), "Old signature should fail after rotation");
+
+    let sig2 = recorder.sign(data);
+    assert!(recorder.verify(data, &sig2));
+}

--- a/samples/vov_log_sample.jsonl
+++ b/samples/vov_log_sample.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2024-01-01T00:00:00Z","event":"key_rotated","hmac":"000000"}
+{"timestamp":"2024-01-01T00:00:01Z","event":"log_signed","hmac":"111111"}

--- a/scripts/write_work_results.sh
+++ b/scripts/write_work_results.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Simple helper to dump final CI results
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <message>" >&2
+    exit 1
+fi
+
+echo "$1" > work_results.txt


### PR DESCRIPTION
## Summary
- add Makefile for flatbuffers regeneration
- hook up Makefile in CI workflow
- extend `LogRecorder` and add unit tests
- test consistency between key generation and signature helpers
- provide coordination node skeleton
- version control a sample VoV log output
- add gitignore/gitattributes and helper script

## Testing
- `cargo test --manifest-path rust-core/Cargo.toml` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686c44ada7508333aa5dbbd43d8f13b9