### PR TITLE
Add Docker build integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
         run: pytest -q
       - name: Validate example logs
         run: python scripts/validate_logs.py --check vov/example_log.jsonl
+      - name: Build Docker image
+        run: docker build -t kairo-cli .
 
   flatbuffers_check:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM rust:1.75 as builder
+WORKDIR /usr/src/kairo
+COPY . .
+RUN cargo build --release --manifest-path AI-TCP/core/kairo_coord_node/Cargo.toml
+
+FROM debian:buster-slim
+COPY --from=builder /usr/src/kairo/target/release/kairo_coord_node /usr/local/bin/kairo_coord_node
+ENTRYPOINT ["kairo_coord_node"]


### PR DESCRIPTION
## Summary
- provide Dockerfile that builds the coordination node CLI
- build the Docker image in the CI workflow

## Testing
- `cargo test --manifest-path rust-core/Cargo.toml` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `pytest -q`
- `docker build -t kairo-cli .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d741772148333afc2010b57106980