### PR TITLE
Add packet validator with tests

### DIFF
--- a/rust-core/src/lib.rs
+++ b/rust-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod force_disconnect;     // Force disconnect logic
 pub mod fw_filter;            // Firewall filter logic
 pub mod packet_parser;        // FlatBuffers parsing + sequence validation
 pub mod packet_signer;        // Ephemeral Key signing for packets
+pub mod packet_validator;        // Packet validation
 pub mod compression;          // LZ4/Zstd compression utilities
 pub mod session;              // Ephemeral DH session management
 pub mod rate_control;         // Adaptive sending rate controller

--- a/rust-core/src/packet_validator.rs
+++ b/rust-core/src/packet_validator.rs
@@ -1,0 +1,44 @@
+use crate::ai_tcp_packet_generated::aitcp as fb;
+use crate::signature::verify_ed25519;
+use ed25519_dalek::{Signature as Ed25519Signature, VerifyingKey};
+
+/// Validate an `AITcpPacket` by checking its sequence number and signature.
+///
+/// The sequence number is expected to be stored in little endian format in
+/// `encrypted_sequence_id`. The signature is assumed to be over the
+/// `encrypted_payload` bytes.
+pub fn validate_packet(
+    packet: &fb::AITcpPacket,
+    verifying_key: &VerifyingKey,
+    expected_sequence: u64,
+) -> bool {
+    // Verify sequence number
+    let seq_vec = packet.encrypted_sequence_id();
+    if seq_vec.len() != 8 {
+        return false;
+    }
+    let mut seq_bytes = [0u8; 8];
+    for (dst, src) in seq_bytes.iter_mut().zip(seq_vec.iter()) {
+        *dst = *src;
+    }
+    let seq = u64::from_le_bytes(seq_bytes);
+    if seq != expected_sequence {
+        return false;
+    }
+
+    // Prepare signature and message
+    let sig_vec = packet.signature();
+    if sig_vec.len() != 64 {
+        return false;
+    }
+    let mut sig_bytes = [0u8; 64];
+    for (dst, src) in sig_bytes.iter_mut().zip(sig_vec.iter()) {
+        *dst = *src;
+    }
+    let signature = match Ed25519Signature::from_bytes(&sig_bytes) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let message: Vec<u8> = packet.encrypted_payload().iter().copied().collect();
+    verify_ed25519(verifying_key, &message, &signature).is_ok()
+}

--- a/rust-core/tests/packet_validator_test.rs
+++ b/rust-core/tests/packet_validator_test.rs
@@ -1,0 +1,77 @@
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use flatbuffers::FlatBufferBuilder;
+use rand_core::OsRng;
+use rust_core::ai_tcp_packet_generated::aitcp as fb;
+use rust_core::packet_validator::validate_packet;
+use rust_core::signature::sign_ed25519;
+
+fn build_packet(seq: u64, key: &SigningKey, payload: &[u8]) -> Vec<u8> {
+    let mut builder = FlatBufferBuilder::new();
+    let ephemeral_key_vec = builder.create_vector(&[1u8; 32]);
+    let nonce_vec = builder.create_vector(&[0u8; 12]);
+    let seq_vec = builder.create_vector(&seq.to_le_bytes());
+    let payload_vec = builder.create_vector(payload);
+    let sig = sign_ed25519(key, payload);
+    let sig_vec = builder.create_vector(sig.as_ref());
+    let packet_offset = fb::AITcpPacket::create(
+        &mut builder,
+        &fb::AITcpPacketArgs {
+            version: 1,
+            ephemeral_key: Some(ephemeral_key_vec),
+            nonce: Some(nonce_vec),
+            encrypted_sequence_id: Some(seq_vec),
+            encrypted_payload: Some(payload_vec),
+            signature: Some(sig_vec),
+        },
+    );
+    builder.finish(packet_offset, None);
+    builder.finished_data().to_vec()
+}
+
+#[test]
+fn validate_success() {
+    let key = SigningKey::generate(&mut OsRng);
+    let payload = b"hello";
+    let buf = build_packet(1, &key, payload);
+    let packet = fb::root_as_aitcp_packet(&buf).unwrap();
+    assert!(validate_packet(&packet, &VerifyingKey::from(&key), 1));
+}
+
+#[test]
+fn validate_wrong_sequence() {
+    let key = SigningKey::generate(&mut OsRng);
+    let payload = b"hello";
+    let buf = build_packet(1, &key, payload);
+    let packet = fb::root_as_aitcp_packet(&buf).unwrap();
+    assert!(!validate_packet(&packet, &VerifyingKey::from(&key), 2));
+}
+
+#[test]
+fn validate_bad_signature() {
+    let key = SigningKey::generate(&mut OsRng);
+    let payload = b"hello";
+    let buf = build_packet(1, &key, payload);
+    let mut packet = fb::root_as_aitcp_packet(&buf).unwrap();
+    // Rebuild with tampered signature
+    let mut builder = FlatBufferBuilder::new();
+    let ephemeral_key_vec = builder.create_vector(&[1u8; 32]);
+    let nonce_vec = builder.create_vector(&[0u8; 12]);
+    let seq_vec = builder.create_vector(&1u64.to_le_bytes());
+    let payload_vec = builder.create_vector(payload);
+    let sig_vec = builder.create_vector(&[0u8; 64]);
+    let packet_offset = fb::AITcpPacket::create(
+        &mut builder,
+        &fb::AITcpPacketArgs {
+            version: 1,
+            ephemeral_key: Some(ephemeral_key_vec),
+            nonce: Some(nonce_vec),
+            encrypted_sequence_id: Some(seq_vec),
+            encrypted_payload: Some(payload_vec),
+            signature: Some(sig_vec),
+        },
+    );
+    builder.finish(packet_offset, None);
+    let tampered_buf = builder.finished_data();
+    packet = fb::root_as_aitcp_packet(tampered_buf).unwrap();
+    assert!(!validate_packet(&packet, &VerifyingKey::from(&key), 1));
+}


### PR DESCRIPTION
## Summary
- implement `packet_validator` module for verifying signatures and sequence numbers
- expose the new module from the crate
- add integration tests for the validator

## Testing
- `cargo test --tests packet_validator_test --no-run` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_686d7413d13883339c56fc2a2df372de