### PR TITLE
Add conflict_resolver skeleton

### DIFF
--- a/src/kairo/resolvers/conflict_resolver.rs
+++ b/src/kairo/resolvers/conflict_resolver.rs
@@ -1,0 +1,56 @@
+//! # Conflict Resolver
+//! Handles logical conflicts and exceptions within the KAIRO Mesh.
+//! This module acts as the immune system of the thinking circuit.
+
+/// Enum to define the types of logical conflicts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LogicalConflictType {
+    /// Case 1: Two or more trusted nodes derived contradictory conclusions from the same Axiom.
+    Contradiction { node_ids: Vec<String>, conflicting_conclusions: Vec<String> },
+
+    /// Case 2: A thought process is detected to be in an infinite loop.
+    InfiniteLoop { entry_node_id: String, loop_signature: String },
+
+    /// Case 3: The foundational Axiom is suspected to be polluted or invalid.
+    AxiomPollution { axiom_hash: String, reason: String },
+}
+
+/// A report struct containing details of a detected conflict.
+#[derive(Debug, Clone)]
+pub struct ConflictReport {
+    pub timestamp: u64,
+    pub conflict_type: LogicalConflictType,
+}
+
+/// Trait for any conflict resolution strategy.
+/// This allows for multiple resolution algorithms to be implemented.
+pub trait ConflictResolver {
+    /// Resolves a given conflict and returns a proposed action.
+    fn resolve(&self, report: ConflictReport) -> Resolution;
+}
+
+/// Enum for the actions to be taken after resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// Escalate the issue for human intervention.
+    EscalateToHuman,
+    
+    /// Rollback the entire thought process to a safe state.
+    RollbackProcess { axiom_hash: String },
+
+    /// Isolate the faulting node(s) from the mesh.
+    IsolateNode { node_id: String },
+}
+
+/// A default resolver implementation.
+pub struct DefaultResolver;
+
+impl ConflictResolver for DefaultResolver {
+    fn resolve(&self, report: ConflictReport) -> Resolution {
+        // For now, the default action for any conflict is to escalate.
+        // More sophisticated logic will be implemented later.
+        println!("Conflict detected: {:?}. Escalating to human operator.", report.conflict_type);
+        Resolution::EscalateToHuman
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `conflict_resolver` module under `src/kairo/resolvers`
- define conflict types and resolution trait
- add a default resolver implementation

## Testing
- `cargo test --manifest-path rust-core/Cargo.toml --verbose` *(fails: failed to download from https://index.crates.io)*
- `pytest -q`
- `python scripts/validate_logs.py --check vov/example_log.jsonl`


------
https://chatgpt.com/codex/tasks/task_e_687016df27d883339bb3d1cff4c2af06