### PR TITLE
Fix tests for updated FlatBuffers schema

### DIFF
--- a/rust-core/tests/aitcp_roundtrip.rs
+++ b/rust-core/tests/aitcp_roundtrip.rs
@@ -9,23 +9,26 @@ fn aitcp_packet_binary_roundtrip() {
 
     let mut builder = FlatBufferBuilder::new();
     let header_vec = builder.create_vector(&header);
+    let payload_vec = builder.create_vector(&payload);
+    let signature_vec = builder.create_vector(&footer);
+    let footer_vec = builder.create_vector(&footer);
+    let ephemeral_vec = builder.create_vector(&[0u8; 32]);
     let nonce_vec = builder.create_vector(&[0u8; 12]);
     let seq_vec = builder.create_vector(&1u64.to_le_bytes());
-    let payload_vec = builder.create_vector(&payload);
-    let footer_vec = builder.create_vector(&footer);
+    let enc_payload_vec = builder.create_vector(&payload);
 
     let pkt = fb::AITcpPacket::create(
         &mut builder,
         &fb::AITcpPacketArgs {
             version: 1,
-            ephemeral_key: Some(header_vec),
+            ephemeral_key: Some(ephemeral_vec),
             nonce: Some(nonce_vec),
             encrypted_sequence_id: Some(seq_vec),
-            encrypted_payload: Some(payload_vec),
-            signature: Some(footer_vec),
-            header: None,
-            payload: None,
-            footer: None,
+            encrypted_payload: Some(enc_payload_vec),
+            signature: Some(signature_vec),
+            header: Some(header_vec),
+            payload: Some(payload_vec),
+            footer: Some(footer_vec),
         },
     );
     builder.finish(pkt, None);
@@ -33,10 +36,10 @@ fn aitcp_packet_binary_roundtrip() {
 
     let parsed = fb::root_as_aitcp_packet(buf).unwrap();
     assert_eq!(parsed.version(), 1);
-    assert_eq!(parsed.ephemeral_key().len(), header.len());
-    assert_eq!(parsed.encrypted_payload().len(), payload.len());
-    assert_eq!(parsed.signature().len(), footer.len());
-    assert_eq!(parsed.ephemeral_key().iter().collect::<Vec<_>>(), header);
-    assert_eq!(parsed.encrypted_payload().iter().collect::<Vec<_>>(), payload);
-    assert_eq!(parsed.signature().iter().collect::<Vec<_>>(), footer);
+    assert_eq!(parsed.header().unwrap().len(), header.len());
+    assert_eq!(parsed.payload().unwrap().len(), payload.len());
+    assert_eq!(parsed.footer().unwrap().len(), footer.len());
+    assert_eq!(parsed.header().unwrap().iter().collect::<Vec<_>>(), header);
+    assert_eq!(parsed.payload().unwrap().iter().collect::<Vec<_>>(), payload);
+    assert_eq!(parsed.footer().unwrap().iter().collect::<Vec<_>>(), footer);
 }

--- a/rust-core/tests/crypto_stress.rs
+++ b/rust-core/tests/crypto_stress.rs
@@ -33,6 +33,9 @@ fn crypto_stress() {
                 encrypted_sequence_id: Some(seq_id_vec),
                 encrypted_payload: Some(payload_vec),
                 signature: Some(signature_vec),
+                header: None,
+                payload: None,
+                footer: None,
             },
         );
 

--- a/rust-core/tests/packet_parser_test.rs
+++ b/rust-core/tests/packet_parser_test.rs
@@ -24,6 +24,9 @@ fn test_packet_parsing_success() {
         // コンパイラの指摘に従い、必須フィールドを追加する
         encrypted_payload: Some(payload_vec),
         signature: Some(signature_vec),
+        header: None,
+        payload: None,
+        footer: None,
     });
     builder.finish(packet_offset, None);
     let buf = builder.finished_data();

--- a/rust-core/tests/packet_validator_test.rs
+++ b/rust-core/tests/packet_validator_test.rs
@@ -3,6 +3,7 @@
 // ===========================
 
 use ed25519_dalek::{SigningKey, VerifyingKey};
+use rust_core::keygen::ephemeral_key;
 use flatbuffers::FlatBufferBuilder;
 use rand_core::OsRng;
 use rust_core::ai_tcp_packet_generated::aitcp as fb;
@@ -27,6 +28,9 @@ fn build_packet(seq: u64, key: &SigningKey, payload: &[u8]) -> Vec<u8> {
             encrypted_sequence_id: Some(seq_vec),
             encrypted_payload: Some(payload_vec),
             signature: Some(sig_vec),
+            header: None,
+            payload: None,
+            footer: None,
         },
     );
     builder.finish(packet_offset, None);
@@ -35,7 +39,7 @@ fn build_packet(seq: u64, key: &SigningKey, payload: &[u8]) -> Vec<u8> {
 
 #[test]
 fn validate_success() {
-    let key = SigningKey::generate(&mut OsRng);
+    let key = SigningKey::from_bytes(&ephemeral_key());
     let payload = b"hello";
     let buf = build_packet(1, &key, payload);
     let packet = fb::root_as_aitcp_packet(&buf).unwrap();
@@ -44,7 +48,7 @@ fn validate_success() {
 
 #[test]
 fn validate_wrong_sequence() {
-    let key = SigningKey::generate(&mut OsRng);
+    let key = SigningKey::from_bytes(&ephemeral_key());
     let payload = b"hello";
     let buf = build_packet(1, &key, payload);
     let packet = fb::root_as_aitcp_packet(&buf).unwrap();
@@ -53,7 +57,7 @@ fn validate_wrong_sequence() {
 
 #[test]
 fn validate_bad_signature() {
-    let key = SigningKey::generate(&mut OsRng);
+    let key = SigningKey::from_bytes(&ephemeral_key());
     let payload = b"hello";
     let buf = build_packet(1, &key, payload);
 
@@ -73,6 +77,9 @@ fn validate_bad_signature() {
             encrypted_sequence_id: Some(seq_vec),
             encrypted_payload: Some(payload_vec),
             signature: Some(sig_vec),
+            header: None,
+            payload: None,
+            footer: None,
         },
     );
     builder.finish(packet_offset, None);

--- a/rust-core/tests/signature_verification_test.rs
+++ b/rust-core/tests/signature_verification_test.rs
@@ -29,14 +29,13 @@ fn sha256_verify_with_wrong_signature() {
 }
 
 // --- Ed25519 Signature Test ---
-use ed25519_dalek::{SigningKey, VerifyingKey, Signer};
-use rand_core::{OsRng, RngCore};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use rust_core::keygen::ephemeral_key;
 use crate::signature::{sign_ed25519, verify_ed25519};
 
 #[test]
 fn ed25519_signature_verification() {
-    let mut csprng = OsRng{};
-    let signing_key = SigningKey::generate(&mut csprng);
+    let signing_key = SigningKey::from_bytes(&ephemeral_key());
     let message: &[u8] = b"test";
 
     let signature = sign_ed25519(&signing_key, message);
@@ -45,8 +44,7 @@ fn ed25519_signature_verification() {
 
 #[test]
 fn ed25519_verify_with_wrong_message() {
-    let mut csprng = OsRng{};
-    let signing_key = SigningKey::generate(&mut csprng);
+    let signing_key = SigningKey::from_bytes(&ephemeral_key());
     let message: &[u8] = b"test";
     let wrong_message: &[u8] = b"wrong";
 
@@ -56,8 +54,7 @@ fn ed25519_verify_with_wrong_message() {
 
 #[test]
 fn ed25519_verify_with_wrong_signature() {
-    let mut csprng = OsRng{};
-    let signing_key = SigningKey::generate(&mut csprng);
+    let signing_key = SigningKey::from_bytes(&ephemeral_key());
     let message: &[u8] = b"test";
 
     let mut signature = sign_ed25519(&signing_key, message);


### PR DESCRIPTION
## Summary
- regenerate FlatBuffer schema (fails due to missing `flatc`)
- update packet tests to use new optional fields
- switch tests from `SigningKey::generate` to `SigningKey::from_bytes`

## Testing
- `python3 scripts/update_flatbuffers.py` *(fails: flatc not found)*
- `cargo test --workspace --no-run` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68701bee60908333ac04d924f110e857