### PR TITLE
Fix rust-core tests for Ed25519 v2

### DIFF
--- a/rust-core/src/signature.rs
+++ b/rust-core/src/signature.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 use std::fmt;
 
 #[derive(Clone)]
-pub struct Sha256Signature([u8; 32]);
+pub struct Sha256Signature(pub [u8; 32]);
 
 impl Sha256Signature {
     /// SHA-256 でメッセージを署名（ダイジェスト作成）

--- a/rust-core/tests/ephemeral_signature_test.rs
+++ b/rust-core/tests/ephemeral_signature_test.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::{SigningKey, VerifyingKey, Keypair};
+use ed25519_dalek::{SigningKey, VerifyingKey};
 use rust_core::keygen::ephemeral_key;
 use rust_core::signature::{sign_ed25519, verify_ed25519};
 
@@ -7,8 +7,7 @@ fn ephemeral_key_signature_consistency() {
     let sk_bytes = ephemeral_key();
     let signing = SigningKey::from_bytes(&sk_bytes);
     let verifying = VerifyingKey::from(&signing);
-    let keypair = Keypair{ secret: signing, public: verifying };
     let msg = b"integration-test";
-    let sig = sign_ed25519(&keypair, msg);
-    assert!(verify_ed25519(&keypair.public, msg, &sig));
+    let sig = sign_ed25519(&signing, msg);
+    assert!(verify_ed25519(&verifying, msg, &sig).is_ok());
 }

--- a/rust-core/tests/packet_parser_test.rs
+++ b/rust-core/tests/packet_parser_test.rs
@@ -1,7 +1,7 @@
 // D:\dev\KAIRO\rust-core\tests\packet_parser_test.rs
-use crate::packet_parser::PacketParser;
+use rust_core::packet_parser::PacketParser;
 use flatbuffers::FlatBufferBuilder;
-use crate::ai_tcp_packet_generated::aitcp as fb;
+use rust_core::ai_tcp_packet_generated::aitcp as fb;
 
 #[test]
 fn test_packet_parsing_success() {

--- a/rust-core/tests/signature_verification_test.rs
+++ b/rust-core/tests/signature_verification_test.rs
@@ -24,14 +24,14 @@ fn sha256_verify_with_wrong_message() {
 fn sha256_verify_with_wrong_signature() {
     let msg = b"hello";
     let mut sig = Sha256Signature::sign(msg);
-    sig.tamper(); // Tamper with the signature
+    sig.0[0] ^= 0xFF; // Tamper with the signature
     assert!(!Sha256Signature::verify(msg, &sig));
 }
 
 // --- Ed25519 Signature Test ---
-use ed25519_dalek::{SigningKey, VerifyingKey};
+use ed25519_dalek::{SigningKey, VerifyingKey, Signature};
 use rust_core::keygen::ephemeral_key;
-use crate::signature::{sign_ed25519, verify_ed25519};
+use rust_core::signature::{sign_ed25519, verify_ed25519};
 
 #[test]
 fn ed25519_signature_verification() {
@@ -57,7 +57,9 @@ fn ed25519_verify_with_wrong_signature() {
     let signing_key = SigningKey::from_bytes(&ephemeral_key());
     let message: &[u8] = b"test";
 
-    let mut signature = sign_ed25519(&signing_key, message);
-    signature.tamper(); // Tamper with the signature
-    assert!(verify_ed25519(&signing_key.verifying_key(), message, &signature).is_err());
+    let signature = sign_ed25519(&signing_key, message);
+    let mut bytes = signature.to_bytes();
+    bytes[0] ^= 0xFF; // Tamper with the signature
+    let tampered = Signature::from_bytes(&bytes);
+    assert!(verify_ed25519(&signing_key.verifying_key(), message, &tampered).is_err());
 }


### PR DESCRIPTION
## Summary
- update Sha256Signature definition for test access
- adapt integration tests to ed25519-dalek v2
- fix PacketParser usage in tests
- remove nonexistent log recorder calls

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68704394cfe483338cd8290c5639658e