### PR TITLE
Fix crypto stress and coordination tests

### DIFF
--- a/rust-core/tests/coordination_test.rs
+++ b/rust-core/tests/coordination_test.rs
@@ -1,6 +1,6 @@
 
 
-use crate::coordination::node_manager::NodeManager;
+use rust_core::coordination::node_manager::NodeManager;
 
 #[test]
 fn test_register_node() {

--- a/rust-core/tests/crypto_stress.rs
+++ b/rust-core/tests/crypto_stress.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::{SigningKey, VerifyingKey, SecretKey};
+use ed25519_dalek::{SigningKey, VerifyingKey};
 use rand::rngs::OsRng;
 use rust_core::ai_tcp_packet_generated::aitcp as fb;
 use rust_core::log_recorder::LogRecorder;
@@ -22,9 +22,8 @@ fn test_crypto_stress_multi_threaded() {
             let mut csprng = OsRng;
             for i in 0..iterations_per_thread {
                 // --- Key Generation (修正点) ---
-                // SecretKey から SigningKey/VerifyingKey を生成します。
-                let secret = SecretKey::generate(&mut csprng);
-                let signing_key: SigningKey = SigningKey::from(&secret);
+                // SigningKey::generate で鍵ペアを生成する
+                let signing_key = SigningKey::generate(&mut csprng);
                 let verifying_key: VerifyingKey = VerifyingKey::from(&signing_key);
 
                 // --- Packet Building ---


### PR DESCRIPTION
## Summary
- update crypto stress test key generation for ed25519-dalek v2
- fix path in coordination test to use rust_core

## Testing
- `cargo test --manifest-path rust-core/Cargo.toml --no-run` *(fails: failed to get `flatbuffers` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6870479b63e08333a03933c8d75c04d5