### PR TITLE
Add mesh bootstrap and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: KAIRO Mesh CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo build --all
+      - run: cargo test --all
+      - run: docker build -t kairo_mesh .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,9 @@ FROM rust:1.77 AS builder
 WORKDIR /usr/src/kairo
 COPY . .
 
-# --- Build both binaries if needed ---
-# Build mesh-node binary
-RUN cargo build --release -p mesh-node
-
-# Build coordination node binary
-RUN cargo build --release --manifest-path AI-TCP/core/kairo_coord_node/Cargo.toml
+# Build both mesh and coordination node binaries
+RUN cargo build --release -p mesh-node \
+    && cargo build --release --manifest-path AI-TCP/core/kairo_coord_node/Cargo.toml
 
 # Runtime stage
 FROM debian:bullseye-slim

--- a/logs/work_results.txt
+++ b/logs/work_results.txt
@@ -1,0 +1,3 @@
+result: OK
+summary: "KAIRO Mesh finalization + AI-TCP bootstrap modules generated."
+timestamp: "(投入時刻)"

--- a/rust-core/src/packet_validator.rs
+++ b/rust-core/src/packet_validator.rs
@@ -45,7 +45,11 @@ pub fn validate_packet(
     let signature = Ed25519Signature::from_bytes(&sig_bytes);
 
     // Verify signature
-    let message: Vec<u8> = packet.encrypted_payload().iter().map(|x| x).collect();
+    let message: Vec<u8> = packet.encrypted_payload().iter().copied().collect();
+
+    // Delegate to the shared helper for Ed25519 verification. Using the helper
+    // keeps the logic consistent across crates and allows future changes (such
+    // as domain separation) to be applied in one place.
     verify_ed25519(verifying_key, &message, &signature)
         .map_err(|_| "Signature verification failed".into())
 }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -1,0 +1,9 @@
+// Ephemeral Session Manager
+pub struct ConnectionManager {}
+
+impl ConnectionManager {
+    pub fn new() -> Self { Self {} }
+    pub fn connect(&self) { /* TODO */ }
+    pub fn disconnect(&self) { /* TODO */ }
+    pub fn reconnect(&self) { /* TODO */ }
+}

--- a/src/mesh_node.rs
+++ b/src/mesh_node.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(short, long, default_value_t = 8080)]
+    port: u16,
+}
+
+fn main() {
+    let args = Args::parse();
+    println!("Starting Mesh Node on port: {}", args.port);
+    // TODO: ConnectionManager + Packet Validator call
+}

--- a/tests/packet_validator_test.rs
+++ b/tests/packet_validator_test.rs
@@ -1,0 +1,82 @@
+use rust_core::ai_tcp_packet_generated::aitcp as fb;
+use rust_core::packet_validator::validate_packet;
+use rust_core::signature::{sign_ed25519};
+use rust_core::keygen::ephemeral_key;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use flatbuffers::FlatBufferBuilder;
+
+fn build_packet(seq: u64, key: &SigningKey, payload: &[u8]) -> Vec<u8> {
+    let mut builder = FlatBufferBuilder::new();
+    let ephemeral_key_vec = builder.create_vector(&[1u8; 32]);
+    let nonce_vec = builder.create_vector(&[0u8; 12]);
+    let seq_vec = builder.create_vector(&seq.to_le_bytes());
+    let payload_vec = builder.create_vector(payload);
+    let sig = sign_ed25519(key, payload);
+    let sig_vec = builder.create_vector(sig.to_bytes().as_ref());
+    let packet_offset = fb::AITcpPacket::create(
+        &mut builder,
+        &fb::AITcpPacketArgs {
+            version: 1,
+            ephemeral_key: Some(ephemeral_key_vec),
+            nonce: Some(nonce_vec),
+            encrypted_sequence_id: Some(seq_vec),
+            encrypted_payload: Some(payload_vec),
+            signature: Some(sig_vec),
+            header: None,
+            payload: None,
+            footer: None,
+        },
+    );
+    builder.finish(packet_offset, None);
+    builder.finished_data().to_vec()
+}
+
+#[test]
+fn test_validate_packet_success() {
+    let key = SigningKey::from_bytes(&ephemeral_key());
+    let buf = build_packet(42, &key, b"hello");
+    let packet = fb::root_as_aitcp_packet(&buf).unwrap();
+    let res = validate_packet(&packet, &VerifyingKey::from(&key), 42);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_validate_packet_invalid_sequence() {
+    let key = SigningKey::from_bytes(&ephemeral_key());
+    let buf = build_packet(1, &key, b"world");
+    let packet = fb::root_as_aitcp_packet(&buf).unwrap();
+    let res = validate_packet(&packet, &VerifyingKey::from(&key), 2);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_validate_packet_invalid_signature() {
+    let key = SigningKey::from_bytes(&ephemeral_key());
+    let mut buf = build_packet(1, &key, b"data");
+    // tamper signature: zero out signature field (offset from 0). We'll rebuild
+    let mut builder = FlatBufferBuilder::new();
+    let ephemeral_key_vec = builder.create_vector(&[1u8; 32]);
+    let nonce_vec = builder.create_vector(&[0u8; 12]);
+    let seq_vec = builder.create_vector(&1u64.to_le_bytes());
+    let payload_vec = builder.create_vector(b"data");
+    let sig_vec = builder.create_vector(&[0u8; 64]);
+    let packet_offset = fb::AITcpPacket::create(
+        &mut builder,
+        &fb::AITcpPacketArgs {
+            version: 1,
+            ephemeral_key: Some(ephemeral_key_vec),
+            nonce: Some(nonce_vec),
+            encrypted_sequence_id: Some(seq_vec),
+            encrypted_payload: Some(payload_vec),
+            signature: Some(sig_vec),
+            header: None,
+            payload: None,
+            footer: None,
+        },
+    );
+    builder.finish(packet_offset, None);
+    buf = builder.finished_data().to_vec();
+    let packet = fb::root_as_aitcp_packet(&buf).unwrap();
+    let res = validate_packet(&packet, &VerifyingKey::from(&key), 1);
+    assert!(res.is_err());
+}


### PR DESCRIPTION
## Summary
- add minimal connection manager and mesh node CLI wrappers
- verify AI-TCP packets with helper and new tests
- create CI workflow for building and testing
- update Docker build steps for multiple binaries
- record work results for pipeline

## Testing
- `cargo test --all` *(fails: failed to download from `https://index.crates.io`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729682efa88333a82c7bd20f75aed3