### PR TITLE
Add mesh peer discovery docs and module

### DIFF
--- a/docs/RFC/mesh_node_discovery.md
+++ b/docs/RFC/mesh_node_discovery.md
@@ -1,0 +1,9 @@
+# AI-TCP Mesh Node Discovery RFC
+
+This RFC specifies how nodes discover peers within a given scope.
+Includes Gossip propagation range, first-hop seeding, and fallback flows.
+
+## Key Points
+- get_gossip_range logic per scope (Personal, Family, etc.)
+- Resilience to Seed Node loss
+- Sybil resistance considerations

--- a/docs/RFC/peer_review_failure_modes.md
+++ b/docs/RFC/peer_review_failure_modes.md
@@ -1,0 +1,15 @@
+# AI-TCP Mesh Peer Review Failure Modes RFC
+
+This RFC details potential failure scenarios in distributed Peer Review,
+including Sybil attacks, false trust propagation, and review collusion.
+Proposes detection and mitigation techniques.
+
+## Failure Modes
+- Low quorum
+- Rapid trust inflation
+- Malicious clusters
+
+## Countermeasures
+- Minimum peer thresholds
+- Cross-scope validation
+- External auditing

--- a/src/mesh_peer_discovery.rs
+++ b/src/mesh_peer_discovery.rs
@@ -1,0 +1,26 @@
+//! mesh_peer_discovery.rs
+//! Handles peer discovery within Gossip range.
+
+pub struct MeshPeerDiscovery {}
+
+impl MeshPeerDiscovery {
+    pub fn new() -> Self { Self {} }
+
+    pub fn discover_peers(scope: Scope) -> Vec<String> {
+        // TODO: Implement actual discovery logic
+        // Use Gossip table, Seed Node hints, and local cache
+        println!("Discovering peers for {:?} scope", scope);
+        vec!["peer1".into(), "peer2".into()]
+    }
+
+    pub fn get_gossip_range(scope: Scope) -> usize {
+        match scope {
+            Scope::Personal => 8,
+            Scope::Family => 16,
+            Scope::Group => 64,
+            Scope::Community => 256,
+            Scope::World => 512,
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- document mesh node discovery behaviour
- add peer review failure mode RFC
- stub out mesh peer discovery module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740304d7e88333afdbdc3c86e67eef