### PR TITLE
Add BaselineProfileManager

### DIFF
--- a/src/baseline_profile_manager.rs
+++ b/src/baseline_profile_manager.rs
@@ -1,0 +1,30 @@
+//! baseline_profile_manager.rs
+//! Manages the baseline behavior profiles for each AI agent.
+
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct BehaviorProfile {
+    pub agent_id: String,
+    pub baseline_vector: Vec<f64>,
+    pub version: u64,
+}
+
+#[derive(Debug)]
+pub struct BaselineProfileManager {
+    profiles: HashMap<String, BehaviorProfile>,
+}
+
+impl BaselineProfileManager {
+    pub fn new() -> Self {
+        Self { profiles: HashMap::new() }
+    }
+
+    pub fn update_profile(&mut self, profile: BehaviorProfile) {
+        self.profiles.insert(profile.agent_id.clone(), profile);
+    }
+
+    pub fn get_profile(&self, agent_id: &str) -> Option<&BehaviorProfile> {
+        self.profiles.get(agent_id)
+    }
+}

--- a/tests/baseline_profile_test.rs
+++ b/tests/baseline_profile_test.rs
@@ -1,0 +1,22 @@
+//! baseline_profile_test.rs
+//! Unit tests for the BaselineProfileManager.
+
+#[cfg(test)]
+mod tests {
+    use crate::baseline_profile_manager::{BaselineProfileManager, BehaviorProfile};
+
+    #[test]
+    fn test_profile_management() {
+        let mut manager = BaselineProfileManager::new();
+        let profile = BehaviorProfile {
+            agent_id: "agent_001".to_string(),
+            baseline_vector: vec![1.0, 2.0, 3.0],
+            version: 1,
+        };
+        manager.update_profile(profile.clone());
+
+        let retrieved = manager.get_profile("agent_001").unwrap();
+        assert_eq!(retrieved.agent_id, "agent_001");
+        assert_eq!(retrieved.version, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add baseline profile manager to store agent profiles
- test BaselineProfileManager functionality

## Testing
- `cargo test --quiet` *(fails: failed to load manifest for workspace member)*

------
https://chatgpt.com/codex/tasks/task_e_6875205b50548333989eeac9967c297d