### PR TITLE
Add behavior verification API and tests

### DIFF
--- a/src/mesh_trust_calculator.rs
+++ b/src/mesh_trust_calculator.rs
@@ -1,5 +1,7 @@
 /// Simple trust score calculator skeleton.
 /// Additional trust computation logic can be implemented as needed.
+use crate::baseline_profile_manager::{BaselineProfileManager, BehaviorProfile};
+
 pub struct TrustScoreCalculator;
 
 impl TrustScoreCalculator {
@@ -29,5 +31,24 @@ impl TrustScoreCalculator {
         }
 
         dot_product / (norm_a * norm_b)
+    }
+
+    pub fn verify_agent_behavior(
+        &self,
+        profile_manager: &BaselineProfileManager,
+        agent_id: &str,
+        current_vector: &[f64],
+        cosine_threshold: f64,
+    ) -> bool {
+        if let Some(profile) = profile_manager.get_profile(agent_id) {
+            return self.check_behavior_anomaly(
+                &current_vector,
+                &profile.baseline_vector,
+                cosine_threshold,
+            );
+        }
+        // プロファイルが存在しない場合は、異常とは判断せず、警告を出すなどの対応が考えられる
+        println!("Warning: No baseline profile found for agent {}", agent_id);
+        false
     }
 }

--- a/tests/diagnosis_integration_test.rs
+++ b/tests/diagnosis_integration_test.rs
@@ -1,0 +1,37 @@
+//! diagnosis_integration_test.rs
+//! Unit tests for the integration of behavior diagnosis.
+
+#[cfg(test)]
+mod tests {
+    use crate::mesh_trust_calculator::TrustScoreCalculator;
+    use crate::baseline_profile_manager::{BaselineProfileManager, BehaviorProfile};
+
+    #[test]
+    fn test_behavior_verification_with_profile() {
+        let calculator = TrustScoreCalculator::new();
+        let mut manager = BaselineProfileManager::new();
+
+        // 正常なプロファイルを登録
+        let profile = BehaviorProfile {
+            agent_id: "agent_001".to_string(),
+            baseline_vector: vec![1.0, 2.0, 3.0],
+            version: 1,
+        };
+        manager.update_profile(profile);
+
+        // 正常ケース
+        let normal_vector = vec![1.1, 2.1, 2.9];
+        let is_anomaly_normal = calculator.verify_agent_behavior(&manager, "agent_001", &normal_vector, 0.95);
+        assert_eq!(is_anomaly_normal, false);
+
+        // 異常ケース
+        let abnormal_vector = vec![-1.0, -2.0, -3.0];
+        let is_anomaly_abnormal = calculator.verify_agent_behavior(&manager, "agent_001", &abnormal_vector, 0.95);
+        assert_eq!(is_anomaly_abnormal, true);
+
+        // プロファイルが存在しないケース
+        let unknown_vector = vec![1.0, 2.0, 3.0];
+        let is_anomaly_unknown = calculator.verify_agent_behavior(&manager, "agent_002", &unknown_vector, 0.95);
+        assert_eq!(is_anomaly_unknown, false); // 異常とは判断されない
+    }
+}


### PR DESCRIPTION
## Summary
- add capability to verify agent behavior against stored profiles
- create integration test for behavior diagnosis

## Testing
- `cargo test` *(fails: failed to load manifest)*

------
https://chatgpt.com/codex/tasks/task_e_6875399c87208333bb23841f1bc035b9