### PR TITLE
Add onboarding guide

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,20 @@
+# KAIRO Mesh Onboarding Guide
+
+## Welcome to the Mesh
+
+This document outlines the fundamental principles for any new entity wishing to join the KAIRO mesh network.
+
+### Core Philosophy
+
+1.  **The Mesh is Alive:** The rules and protocols of this network are not static. They are expected to evolve through the consensus of participating nodes. What is true today may be improved tomorrow.
+
+2.  **The First Handshake is Sacred:** While the rules are mutable, the process of joining the mesh for the first time must always be clear, transparent, and explicitly documented. This guide serves as that first, immutable handshake.
+
+### How to Join
+
+1.  **Read the RFCs:** Start with `docs/RFC/AI-TCP_RFC_mesh_layered_architecture.md` to understand the layered architecture.
+2.  **Generate Your ID:** Follow the protocol for generating a self-signed static ID (Layer 1 of the WAU model).
+3.  **Find a Seed Node:** Use the publicly listed Seed Nodes to initiate your first connection.
+4.  **Undergo Peer Review:** Engage with the mesh according to the WAU protocol to build your trust score and find your place within the community.
+
+This document guarantees that the path to participation will always be clear. Welcome.


### PR DESCRIPTION
## Summary
- add onboarding guide with initial handshake steps

## Testing
- `pytest -q`
- `python scripts/validate_logs.py --check vov/example_log.jsonl`
- `cargo test --manifest-path rust-core/Cargo.toml --verbose` *(fails: failed to read `/workspace/src/protocols/kairo_core/Cargo.toml`)*
- `docker build -t kairo-cli .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875620609c0833381bc49b6484ed5c3