### PR TITLE
Fix workspace structure and crate names

### DIFF
--- a/kairof/Cargo.toml
+++ b/kairof/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 flatbuffers = "25.2.10"
 rand = "0.8"
 rand_core = "0.6"
-rust-core = { path = "../rust-core" }
+kairo_rust_core = { path = "../rust-core" }

--- a/kairof/src/lib.rs
+++ b/kairof/src/lib.rs
@@ -1,6 +1,6 @@
 use flatbuffers::FlatBufferBuilder;
 use rand::RngCore;
-use rust_core::ai_tcp_packet_generated::aitcp as fb;
+use kairo_rust_core::ai_tcp_packet_generated::aitcp as fb;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Build a single AITcpPacket with the given sequence id.

--- a/mesh-node/Cargo.toml
+++ b/mesh-node/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-rust-core = { path = "../rust-core" }
+kairo_rust_core = { path = "../rust-core" }

--- a/mesh-node/src/main.rs
+++ b/mesh-node/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use kairo_rust_core::example_function;
 
 /// Simple mesh node example
 #[derive(Parser, Debug)]
@@ -12,6 +13,6 @@ struct Cli {
 fn main() {
     let cli = Cli::parse();
     println!("Starting mesh node on port {}", cli.port);
-    // Call into the shared rust_core library as a sanity check
-    rust_core::example_function();
+    // Call into the shared kairo_rust_core library as a sanity check
+    example_function();
 }

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -21,4 +21,4 @@ uuid = { version = "1.0", features = ["v4"] }
 warp = "0.3"
 thiserror = "1.0"
 zstd = "0.12"
-kairo_core = { path = "../../src/protocols/kairo_core" }
+kairo_core = { path = "./kairo_core" }

--- a/rust-core/benches/benchmark_flatbuffers.rs
+++ b/rust-core/benches/benchmark_flatbuffers.rs
@@ -6,8 +6,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use flatbuffers::FlatBufferBuilder;
 
 // Import generated FlatBuffers schema and packet parser from the crate
-use rust_core::ai_tcp_packet_generated::aitcp as fb;
-use rust_core::packet_parser::PacketParser;
+use kairo_rust_core::ai_tcp_packet_generated::aitcp as fb;
+use kairo_rust_core::packet_parser::PacketParser;
 
 /// Helper function to build a sample AITcpPacket and return the encoded bytes
 fn build_sample_packet() -> Vec<u8> {

--- a/rust-core/kairo_core/Cargo.toml
+++ b/rust-core/kairo_core/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "kairo_core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-core/kairo_core/src/lib.rs
+++ b/rust-core/kairo_core/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod session_reuse;

--- a/rust-core/kairo_core/src/session_reuse.rs
+++ b/rust-core/kairo_core/src/session_reuse.rs
@@ -1,0 +1,7 @@
+pub struct SessionManager;
+
+impl SessionManager {
+    pub fn new() -> Self {
+        SessionManager
+    }
+}

--- a/src/kairo/Cargo.toml
+++ b/src/kairo/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rust-core = { path = "../../rust-core" }
+kairo_rust_core = { path = "../../rust-core" }
 flatbuffers = "24.3.25"
 rand = "0.8.5"
 chrono = "0.4.38"

--- a/tests/packet_validator_test.rs
+++ b/tests/packet_validator_test.rs
@@ -1,7 +1,7 @@
-use rust_core::ai_tcp_packet_generated::aitcp as fb;
-use rust_core::packet_validator::validate_packet;
-use rust_core::signature::{sign_ed25519};
-use rust_core::keygen::ephemeral_key;
+use kairo_rust_core::ai_tcp_packet_generated::aitcp as fb;
+use kairo_rust_core::packet_validator::validate_packet;
+use kairo_rust_core::signature::sign_ed25519;
+use kairo_rust_core::keygen::ephemeral_key;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use flatbuffers::FlatBufferBuilder;
 


### PR DESCRIPTION
## Summary
- create new `kairo_core` crate inside `rust-core`
- update `rust-core` dependency path
- rename dependencies in crates to `kairo_rust_core`
- fix imports in `mesh-node` main file
- adjust tests and benchmark imports

## Testing
- `cargo clean`
- `cargo build` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68761a05bc488333823399b16c101c6e