### PR TITLE
Add setup_agent onboarding utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
   "rust-core"
 ]
 resolver = "1"
+
+[workspace.dependencies]
+hex = "0.4"

--- a/bin/onboard/setup_agent.rs
+++ b/bin/onboard/setup_agent.rs
@@ -1,0 +1,27 @@
+//! bin/onboard/setup_agent.rs
+//! CUI for first-time onboarding to the KAIRO Mesh.
+
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use rand::rngs::OsRng;
+
+fn main() {
+    println!("--- KAIRO Mesh Initial Setup ---");
+
+    println!("\nStep 1: Generating Static ID (ed25519 Key Pair)...");
+    let mut csprng = OsRng;
+    let keypair: SigningKey = SigningKey::generate(&mut csprng);
+    let public_key: VerifyingKey = (&keypair).into();
+
+    let private_key_hex = hex::encode(keypair.to_bytes());
+    let public_key_hex = hex::encode(public_key.as_bytes());
+    println!("-> Key Pair generated successfully.");
+
+    println!("\nStep 2: Registering with a Seed Node...");
+    println!("-> Registration request sent (simulated).");
+
+    println!("\n--- Onboarding Complete ---");
+    println!("Your Mesh Address (Public Key): {}", public_key_hex);
+    println!("Your Agent Token (Secret Key): {}", private_key_hex);
+    println!("\nIMPORTANT: Keep your Agent Token secure. It will not be shown again.");
+    println!("You can now use this token to launch your AI-TCP instance.");
+}


### PR DESCRIPTION
## Summary
- add a new onboarding utility `setup_agent.rs` that generates an ed25519 keypair and prints it in hex
- make the hex crate available workspace‑wide

## Testing
- `cargo test --workspace` *(fails: failed to get `flatbuffers` due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687630d0709c8333b2a7bd4b7b13877f