### PR TITLE
Refactor imports in rust-core tests

### DIFF
--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -22,3 +22,6 @@ warp = "0.3"
 thiserror = "1.0"
 zstd = "0.12"
 kairo_core = { path = "./kairo_core" }
+
+[dev-dependencies]
+criterion = "*"

--- a/rust-core/tests/aitcp_roundtrip.rs
+++ b/rust-core/tests/aitcp_roundtrip.rs
@@ -1,5 +1,5 @@
 use flatbuffers::FlatBufferBuilder;
-use crate::ai_tcp_packet_generated::aitcp as fb;
+use kairo_rust_core::ai_tcp_packet_generated::aitcp as fb;
 
 #[test]
 fn aitcp_packet_binary_roundtrip() {

--- a/rust-core/tests/coordination_test.rs
+++ b/rust-core/tests/coordination_test.rs
@@ -1,4 +1,4 @@
-use crate::coordination::node_manager::NodeManager;
+use kairo_rust_core::coordination::node_manager::NodeManager;
 
 #[test]
 fn test_register_node() {

--- a/rust-core/tests/crypto_stress.rs
+++ b/rust-core/tests/crypto_stress.rs
@@ -1,11 +1,11 @@
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use bytes::Bytes;
-use crate::keygen::ephemeral_key;
+use kairo_rust_core::keygen::ephemeral_key;
 use rand_core::OsRng;
-use crate::ephemeral_session_generated::aitcp as fb;
-use crate::log_recorder::LogRecorder;
-use crate::packet_parser::PacketParser;
-use crate::signature::{sign_ed25519, verify_ed25519};
+use kairo_rust_core::ephemeral_session_generated::aitcp as fb;
+use kairo_rust_core::log_recorder::LogRecorder;
+use kairo_rust_core::packet_parser::PacketParser;
+use kairo_rust_core::signature::{sign_ed25519, verify_ed25519};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;

--- a/rust-core/tests/ephemeral_signature_test.rs
+++ b/rust-core/tests/ephemeral_signature_test.rs
@@ -1,6 +1,6 @@
 use ed25519_dalek::{SigningKey, VerifyingKey};
-use crate::keygen::ephemeral_key;
-use crate::signature::{sign_ed25519, verify_ed25519};
+use kairo_rust_core::keygen::ephemeral_key;
+use kairo_rust_core::signature::{sign_ed25519, verify_ed25519};
 
 #[test]
 fn ephemeral_key_signature_consistency() {

--- a/rust-core/tests/key_rotation_test.rs
+++ b/rust-core/tests/key_rotation_test.rs
@@ -3,7 +3,7 @@
 // ===========================
 
 // --- Keygen テスト ---
-use crate::keygen::ephemeral_key;
+use kairo_rust_core::keygen::ephemeral_key;
 
 #[test]
 fn keys_are_unique() {
@@ -15,7 +15,7 @@ fn keys_are_unique() {
 // --- LogRecorder テスト ---
 use chrono::Utc;
 // crateパスで呼ぶのが安全
-use crate::log_recorder::LogRecorder;
+use kairo_rust_core::log_recorder::LogRecorder;
 
 #[test]
 fn test_key_rotation() {

--- a/rust-core/tests/log_recorder_test.rs
+++ b/rust-core/tests/log_recorder_test.rs
@@ -1,5 +1,5 @@
-use crate::log_recorder::LogRecorder;
-use crate::ai_tcp_packet_generated::aitcp as fb;
+use kairo_rust_core::log_recorder::LogRecorder;
+use kairo_rust_core::ai_tcp_packet_generated::aitcp as fb;
 use std::fs;
 
 #[test]

--- a/rust-core/tests/mesh_auditor_test.rs
+++ b/rust-core/tests/mesh_auditor_test.rs
@@ -3,7 +3,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::mesh_auditor::MeshAuditor;
+    use kairo_rust_core::mesh_auditor::MeshAuditor;
 
     #[test]
     fn test_audit_flow_instantiation() {

--- a/rust-core/tests/packet_parser_test.rs
+++ b/rust-core/tests/packet_parser_test.rs
@@ -1,9 +1,9 @@
 // D:\dev\KAIRO\rust-core\tests\packet_parser_test.rs
-use crate::packet_parser::PacketParser;
+use kairo_rust_core::packet_parser::PacketParser;
 use flatbuffers::FlatBufferBuilder;
 use bytes::Bytes;
-use crate::ai_tcp_packet_generated::aitcp as fb;
-use crate::ephemeral_session_generated::aitcp as fb_ephemeral;
+use kairo_rust_core::ai_tcp_packet_generated::aitcp as fb;
+use kairo_rust_core::ephemeral_session_generated::aitcp as fb_ephemeral;
 
 #[test]
 fn test_packet_parsing_success() {

--- a/rust-core/tests/packet_validator_test.rs
+++ b/rust-core/tests/packet_validator_test.rs
@@ -3,11 +3,11 @@
 // ===========================
 
 use ed25519_dalek::{SigningKey, VerifyingKey};
-use crate::keygen::ephemeral_key;
+use kairo_rust_core::keygen::ephemeral_key;
 use flatbuffers::FlatBufferBuilder;
-use crate::ai_tcp_packet_generated::aitcp as fb;
-use crate::packet_validator::validate_packet;
-use crate::signature::sign_ed25519;
+use kairo_rust_core::ai_tcp_packet_generated::aitcp as fb;
+use kairo_rust_core::packet_validator::validate_packet;
+use kairo_rust_core::signature::sign_ed25519;
 
 /// Build a valid AITcpPacket FlatBuffer for testing.
 fn build_packet(seq: u64, key: &SigningKey, payload: &[u8]) -> Vec<u8> {

--- a/rust-core/tests/signature_verification_test.rs
+++ b/rust-core/tests/signature_verification_test.rs
@@ -3,7 +3,7 @@
 // ===========================
 
 // --- SHA256 Signature Test ---
-use crate::signature::Sha256Signature;
+use kairo_rust_core::signature::Sha256Signature;
 
 #[test]
 fn sha256_sign_and_verify() {
@@ -30,8 +30,8 @@ fn sha256_verify_with_wrong_signature() {
 
 // --- Ed25519 Signature Test ---
 use ed25519_dalek::{SigningKey, Signature};
-use crate::keygen::ephemeral_key;
-use crate::signature::{sign_ed25519, verify_ed25519};
+use kairo_rust_core::keygen::ephemeral_key;
+use kairo_rust_core::signature::{sign_ed25519, verify_ed25519};
 
 #[test]
 fn ed25519_signature_verification() {


### PR DESCRIPTION
## Summary
- fix unresolved imports by using `kairo_rust_core` path in integration tests
- add `criterion` as a dev-dependency for benches

## Testing
- `cargo check --workspace` *(fails: failed to get `flatbuffers` due to network)*
- `cargo test --workspace` *(fails: failed to get `flatbuffers` due to network)*
- `cargo bench --workspace` *(fails: failed to get `flatbuffers` due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6876327790688333907273cbaae8d702