### PR TITLE
Add serde derives for coordination structs

### DIFF
--- a/rust-core/src/coordination/api.rs
+++ b/rust-core/src/coordination/api.rs
@@ -1,16 +1,16 @@
 // D:\dev\KAIRO\rust-core\src\coordination\api.rs
-use warp::Filter;
 use serde::{Deserialize, Serialize};
+use warp::Filter;
 use std::sync::Arc;
 
 use super::node_manager::{NodeManager, Node};
 
-#[derive(Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct RegisterRequest {
     public_key: Vec<u8>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct RegisterResponse {
     virtual_ip: String,
 }
@@ -31,7 +31,7 @@ pub fn peers_route(manager: Arc<NodeManager>) -> impl Filter<Extract = impl warp
         .and_then(handle_peers)
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct PeerQuery {
     id: String,
 }

--- a/rust-core/src/coordination/node_manager.rs
+++ b/rust-core/src/coordination/node_manager.rs
@@ -1,9 +1,10 @@
 // D:\dev\KAIRO\rust-core\src\coordination\node_manager.rs
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
-#[derive(Clone, serde::Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Node {
     pub id: String, // 128-bit Unique ID represented as hex string
     pub public_key: Vec<u8>,


### PR DESCRIPTION
## Summary
- enable serde support for registration API structures
- add Serialize/Deserialize for Node struct

## Testing
- `cargo test --manifest-path rust-core/Cargo.toml --no-run` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68769f7804708333997b59646da57862