### PR TITLE
Add PacketParser placeholder module and test

### DIFF
--- a/src/packet_parser.rs
+++ b/src/packet_parser.rs
@@ -1,0 +1,19 @@
+//! src/packet_parser.rs
+//! Parses AI-TCP packets from raw bytes, handling validation and deserialization.
+
+// session_key is currently unused and has been removed to clean up the data structure.
+// Security and session management are handled by the WAU model and cryptographic signatures.
+
+pub struct PacketParser {}
+
+impl PacketParser {
+    pub fn new() -> Self {
+        PacketParser {}
+    }
+
+    // Existing functions of PacketParser would be here...
+    // For now, we are just ensuring the structure is clean.
+    pub fn placeholder_function(&self) -> bool {
+        true
+    }
+}

--- a/tests/packet_parser_test.rs
+++ b/tests/packet_parser_test.rs
@@ -1,0 +1,12 @@
+//! tests/packet_parser_test.rs
+
+#[cfg(test)]
+mod tests {
+    use crate::packet_parser::PacketParser; // Updated path
+
+    #[test]
+    fn test_parser_instantiation() {
+        let parser = PacketParser::new();
+        assert!(parser.placeholder_function());
+    }
+}


### PR DESCRIPTION
## Summary
- add a basic PacketParser module in `src`
- include a placeholder test for packet parser instantiation

## Testing
- `cargo test --workspace --no-run` *(fails: unable to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_6876a6b9ace883339009a4c6df62aed5