### PR TITLE
Fix crypto stress test for latest ed25519-dalek

### DIFF
--- a/rust-core/tests/crypto_stress.rs
+++ b/rust-core/tests/crypto_stress.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::{Keypair, VerifyingKey};
+use ed25519_dalek::{SigningKey, VerifyingKey};
 use bytes::Bytes;
 use kairo_rust_core::keygen::ephemeral_key;
 use rand::rngs::OsRng;
@@ -23,9 +23,9 @@ fn test_crypto_stress_multi_threaded() {
         let handle = thread::spawn(move || {
             for i in 0..iterations_per_thread {
                 // --- Key Generation ---
-                let keypair = Keypair::generate(&mut OsRng);
-                let signing_key = keypair.secret;
-                let verifying_key = keypair.public;
+                let signing_key = SigningKey::generate(&mut OsRng);
+                let verifying_key = VerifyingKey::from(&signing_key);
+                // signing_key and verifying_key generated above
 
                 // --- Packet Building ---
                 let mut builder = flatbuffers::FlatBufferBuilder::new();


### PR DESCRIPTION
## Summary
- update crypto_stress.rs to use `SigningKey` instead of `Keypair`
- adjust key generation accordingly

## Testing
- `cargo test --workspace --tests` *(fails: failed to download crates due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6876c918b0588333af3055ad8bf5c8a1