### PR TITLE
Update crypto stress test to use Keypair

### DIFF
--- a/rust-core/tests/crypto_stress.rs
+++ b/rust-core/tests/crypto_stress.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::{SigningKey, VerifyingKey};
+use ed25519_dalek::{Keypair, VerifyingKey};
 use bytes::Bytes;
 use kairo_rust_core::keygen::ephemeral_key;
 use rand::rngs::OsRng;
@@ -23,7 +23,9 @@ fn test_crypto_stress_multi_threaded() {
         let handle = thread::spawn(move || {
             for i in 0..iterations_per_thread {
                 // --- Key Generation ---
-                let signing_key = SigningKey::generate(&mut OsRng);
+                let keypair = Keypair::generate(&mut OsRng);
+                let signing_key = keypair.secret;
+                let verifying_key = keypair.public;
                 let verifying_key = VerifyingKey::from(&signing_key);
                 // signing_key and verifying_key generated above
 


### PR DESCRIPTION
## Summary
- fix crypto_stress.rs to use ed25519_dalek Keypair

## Testing
- `cargo test --manifest-path rust-core/Cargo.toml --quiet` *(fails: failed to download from index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6876cc9659148333ad4b70bf6168fe64