### PR TITLE
Fix PacketParser construction

### DIFF
--- a/rust-core/src/packet_parser.rs
+++ b/rust-core/src/packet_parser.rs
@@ -48,7 +48,7 @@ pub struct PacketParser {
 
 impl PacketParser {
     pub fn new(session_key: Vec<u8>) -> Self {
-        PacketParser { session_key }
+        PacketParser {}
     }
 
     pub fn parse(&mut self, data: &Bytes) -> Result<Packet, Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary
- fix packet parser constructor to remove unused session_key

## Testing
- `pytest -q`
- `python scripts/validate_logs.py --check vov/example_log.jsonl`
- `cargo test --manifest-path rust-core/Cargo.toml --verbose` *(fails: failed to download crates)*
- `docker build -t kairo-cli .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876d334eeec8333a88d24378a9b569e