### PR TITLE
Fix crypto stress tests

### DIFF
--- a/rust-core/tests/crypto_stress.rs
+++ b/rust-core/tests/crypto_stress.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::{SigningKey, VerifyingKey};
+use ed25519_dalek::{Keypair, VerifyingKey};
 use bytes::Bytes;
 use kairo_rust_core::keygen::ephemeral_key;
 use rand::rngs::OsRng;
@@ -23,8 +23,8 @@ fn test_crypto_stress_multi_threaded() {
         let handle = thread::spawn(move || {
             for i in 0..iterations_per_thread {
                 // --- Key Generation ---
-                let signing_key = SigningKey::generate(&mut OsRng);
-                let verifying_key: VerifyingKey = (&signing_key).into();
+                let signing_key = Keypair::generate(&mut OsRng);
+                let verifying_key: VerifyingKey = signing_key.public;
                 // signing_key and verifying_key generated above
 
                 // --- Packet Building ---
@@ -45,7 +45,7 @@ fn test_crypto_stress_multi_threaded() {
 
                 // --- Signing ---
                 // 生成したkeypairをそのまま署名に使用します。
-                let signature = sign_ed25519(&signing_key, buf);
+                let signature = sign_ed25519(&signing_key.secret, buf);
 
                 // --- Verification ---
                 // keypairから公開鍵(.public)を取り出して検証に使用します。

--- a/rust-core/tests/packet_parser_test.rs
+++ b/rust-core/tests/packet_parser_test.rs
@@ -1,7 +1,6 @@
 use kairo_rust_core::packet_parser::PacketParser;
 use flatbuffers::FlatBufferBuilder;
 use bytes::Bytes;
-use kairo_rust_core::ai_tcp_packet_generated::aitcp as fb;
 use kairo_rust_core::ephemeral_session_generated::aitcp as fb_ephemeral;
 
 #[test]

--- a/rust-core/tests/packet_validator_test.rs
+++ b/rust-core/tests/packet_validator_test.rs
@@ -40,8 +40,8 @@ fn build_packet(seq: u64, key: &SigningKey, payload: &[u8]) -> Vec<u8> {
 fn validate_success() {
     let key = SigningKey::from_bytes(&ephemeral_key());
     let payload = b"hello";
-    let buf = build_packet(1, &key, payload);
-    let packet = fb::root_as_aitcp_packet(&buf).unwrap();
+    let _buf = build_packet(1, &key, payload);
+    let packet = fb::root_as_aitcp_packet(&_buf).unwrap();
     assert!(validate_packet(&packet, &VerifyingKey::from(&key), 1).is_ok());
 }
 
@@ -49,8 +49,8 @@ fn validate_success() {
 fn validate_wrong_sequence() {
     let key = SigningKey::from_bytes(&ephemeral_key());
     let payload = b"hello";
-    let buf = build_packet(1, &key, payload);
-    let packet = fb::root_as_aitcp_packet(&buf).unwrap();
+    let _buf = build_packet(1, &key, payload);
+    let packet = fb::root_as_aitcp_packet(&_buf).unwrap();
     assert!(validate_packet(&packet, &VerifyingKey::from(&key), 2).is_err());
 }
 
@@ -58,7 +58,7 @@ fn validate_wrong_sequence() {
 fn validate_bad_signature() {
     let key = SigningKey::from_bytes(&ephemeral_key());
     let payload = b"hello";
-    let buf = build_packet(1, &key, payload);
+    let _buf = build_packet(1, &key, payload);
 
     // Tamper signature: build new buffer with zeroed signature
     let mut builder = FlatBufferBuilder::new();


### PR DESCRIPTION
## Summary
- update ed25519 key generation to `Keypair::generate`
- silence unused variable warnings in packet validator test
- remove unused import from packet parser test

## Testing
- `cargo test -p kairo_rust_core --tests --no-run` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68778fa805708333b1688096087c58c6