### PR TITLE
Add seed node E2E test

### DIFF
--- a/bin/onboard/setup_agent.rs
+++ b/bin/onboard/setup_agent.rs
@@ -56,3 +56,19 @@ fn register_with_seed_node(public_key: &str) -> Result<(), reqwest::Error> {
         }
     }
 }
+
+// 実接続テスト用: シードノード登録の E2E テストケース
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_with_seed_node_live() {
+        let dummy_pubkey = "test_public_key_123";
+        let result = register_with_seed_node(dummy_pubkey);
+        match result {
+            Ok(_) => println!("✅ Seed node registration attempt succeeded."),
+            Err(e) => panic!("❌ Seed node registration failed: {:?}", e),
+        }
+    }
+}

--- a/rust-core/src/packet_parser.rs
+++ b/rust-core/src/packet_parser.rs
@@ -47,7 +47,8 @@ pub struct PacketParser {
 }
 
 impl PacketParser {
-    pub fn new(session_key: Vec<u8>) -> Self {
+// Removed unused session_key
+    pub fn new() -> Self {
         PacketParser {}
     }
 


### PR DESCRIPTION
## Summary
- clean up unused param in `PacketParser::new`
- add live E2E test for seed node registration CLI

## Testing
- `cargo fmt`
- `cargo test --workspace --locked --offline` *(fails: no matching package named `rand` found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d279bda8833383f437e1d5a3bce4