### PR TITLE
Add seed node server implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ resolver = "1"
 hex = "0.4"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 tokio = { version = "1", features = ["full"] }
+warp = "0.3"
+serde = { version = "1.0", features = ["derive"] }

--- a/src/bin/seed_node.rs
+++ b/src/bin/seed_node.rs
@@ -1,0 +1,26 @@
+//! src/bin/seed_node.rs
+//! The actual Seed Node server implementation.
+
+use warp::Filter;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct RegisterRequest {
+    agent_id: String,
+}
+
+#[tokio::main]
+async fn main() {
+    println!("KAIRO Seed Node starting...");
+
+    let register = warp::post()
+        .and(warp::path("register"))
+        .and(warp::body::json())
+        .map(|req: RegisterRequest| {
+            println!("Received registration for agent_id: {}", req.agent_id);
+            warp::reply::json(&"success")
+        });
+
+    println!("Listening on http://127.0.0.1:8080/register");
+    warp::serve(register).run(([127, 0, 0, 1], 8080)).await;
+}


### PR DESCRIPTION
## Summary
- implement basic seed node server at `src/bin/seed_node.rs`
- add `warp` and `serde` to workspace dependencies

## Testing
- `cargo test --manifest-path rust-core/Cargo.toml --verbose` *(fails: failed to download from https://index.crates.io)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877df594aa4833391b63a336e222ba9