### PR TITLE
Enhance seed node persistence

### DIFF
--- a/src/bin/seed_node.rs
+++ b/src/bin/seed_node.rs
@@ -1,54 +1,75 @@
 //! src/bin/seed_node.rs
-//! The actual Seed Node server implementation with persistence.
+//! The actual Seed Node server implementation with JSON persistence and duplicate checking.
 
-use warp::Filter;
-use serde::Deserialize;
-use std::fs::OpenOptions;
-use std::io::Write;
+use warp::{Filter, Rejection, Reply};
+use serde::{Deserialize, Serialize};
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, BufWriter, Write};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 struct RegisterRequest {
     agent_id: String,
 }
 
-// A simple function to append the agent_id to a file.
-fn persist_agent(agent_id: &str) -> std::io::Result<()> {
-    let mut file = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .append(true)
-        .open("registered_agents.txt")?;
+#[derive(Debug, Serialize)]
+struct RegisterResponse {
+    status: String,
+    message: String,
+}
 
-    writeln!(file, "{}", agent_id)
+const DB_FILE: &str = "registered_agents.json";
+
+// Reads agent IDs from the JSON file.
+fn read_agents() -> Result<Vec<String>, std::io::Error> {
+    let file = File::open(DB_FILE).unwrap_or_else(|_| File::create(DB_FILE).unwrap());
+    let reader = BufReader::new(file);
+    let agents = serde_json::from_reader(reader).unwrap_or_else(|_| Vec::new());
+    Ok(agents)
+}
+
+// Writes the list of agent IDs to the JSON file.
+fn write_agents(agents: &[String]) -> std::io::Result<()> {
+    let file = OpenOptions::new().write(true).truncate(true).create(true).open(DB_FILE)?;
+    let writer = BufWriter::new(file);
+    serde_json::to_writer_pretty(writer, agents)?;
+    Ok(())
+}
+
+async fn handle_registration(req: RegisterRequest, db_lock: Arc<Mutex<()>>) -> Result<impl Reply, Rejection> {
+    let _lock = db_lock.lock().await;
+    println!("Received registration for agent_id: {}", req.agent_id);
+
+    let mut agents = read_agents().expect("Failed to read from DB");
+
+    if agents.contains(&req.agent_id) {
+        println!("Agent {} already registered.", req.agent_id);
+        let res = RegisterResponse { status: "exists".to_string(), message: "Agent already registered".to_string() };
+        Ok(warp::reply::json(&res))
+    } else {
+        agents.push(req.agent_id.clone());
+        write_agents(&agents).expect("Failed to write to DB");
+        println!("Successfully registered agent {}.", req.agent_id);
+        let res = RegisterResponse { status: "success".to_string(), message: "Agent successfully registered".to_string() };
+        Ok(warp::reply::json(&res))
+    }
 }
 
 #[tokio::main]
 async fn main() {
     println!("KAIRO Seed Node starting...");
 
-    // Wrap the persistence logic in a mutex for safe concurrent access if needed in the future.
-    let log_file = Arc::new(Mutex::new(()));
+    let db_lock = Arc::new(Mutex::new(()));
 
     let register = warp::post()
         .and(warp::path("register"))
         .and(warp::body::json())
-        .and(warp::any().map(move || Arc::clone(&log_file)))
-        .and_then(|req: RegisterRequest, _lock: Arc<Mutex<()>>| async move {
-            println!("Received registration for agent_id: {}", req.agent_id);
-            if let Err(e) = persist_agent(&req.agent_id) {
-                eprintln!("Error persisting agent: {}", e);
-                return Err(warp::reject::custom(RegistrationError));
-            }
-            Ok(warp::reply::json(&"success"))
-        });
+        .and(warp::any().map(move || Arc::clone(&db_lock)))
+        .and_then(handle_registration);
 
     println!("Listening on http://127.0.0.1:8080/register");
-    println!("Registrations will be saved to registered_agents.txt");
+    println!("Registrations will be saved to registered_agents.json");
     warp::serve(register).run(([127, 0, 0, 1], 8080)).await;
 }
 
-#[derive(Debug)]
-struct RegistrationError;
-impl warp::reject::Reject for RegistrationError {}


### PR DESCRIPTION
## Summary
- replace text file storage with JSON file for seed node
- handle concurrent writes with a mutex
- prevent duplicate agent registrations

## Testing
- `cargo test` *(fails: failed to download crates)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877eefce8248333b067f2c3f77f5f3d