### PR TITLE
Add structured registry to seed node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
 
 [[bin]]
 name = "setup_agent"

--- a/bin/dev/seed_node.rs
+++ b/bin/dev/seed_node.rs
@@ -1,5 +1,5 @@
 //! bin/dev/seed_node.rs
-//! The actual Seed Node server implementation with JSON persistence and duplicate checking.
+//! Seed Node with structured JSON persistence.
 
 use warp::{Filter, Rejection, Reply};
 use serde::{Deserialize, Serialize};
@@ -7,6 +7,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Write};
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use chrono::{DateTime, Utc};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 struct RegisterRequest {
@@ -19,21 +20,26 @@ struct RegisterResponse {
     message: String,
 }
 
-const DB_FILE: &str = "registered_agents.json";
-
-// Reads agent IDs from the JSON file.
-fn read_agents() -> Result<Vec<String>, std::io::Error> {
-    let file = File::open(DB_FILE).unwrap_or_else(|_| File::create(DB_FILE).unwrap());
-    let reader = BufReader::new(file);
-    let agents = serde_json::from_reader(reader).unwrap_or_else(|_| Vec::new());
-    Ok(agents)
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct AgentInfo {
+    agent_id: String,
+    registered_at: String,
+    status: String, // e.g., "active", "revoked"
 }
 
-// Writes the list of agent IDs to the JSON file.
-fn write_agents(agents: &[String]) -> std::io::Result<()> {
+const DB_FILE: &str = "registry.json";
+
+fn read_registry() -> Result<Vec<AgentInfo>, std::io::Error> {
+    let file = File::open(DB_FILE).unwrap_or_else(|_| File::create(DB_FILE).unwrap());
+    let reader = BufReader::new(file);
+    let registry = serde_json::from_reader(reader).unwrap_or_else(|_| Vec::new());
+    Ok(registry)
+}
+
+fn write_registry(registry: &[AgentInfo]) -> std::io::Result<()> {
     let file = OpenOptions::new().write(true).truncate(true).create(true).open(DB_FILE)?;
     let writer = BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, agents)?;
+    serde_json::to_writer_pretty(writer, registry)?;
     Ok(())
 }
 
@@ -41,15 +47,20 @@ async fn handle_registration(req: RegisterRequest, db_lock: Arc<Mutex<()>>) -> R
     let _lock = db_lock.lock().await;
     println!("Received registration for agent_id: {}", req.agent_id);
 
-    let mut agents = read_agents().expect("Failed to read from DB");
+    let mut registry = read_registry().expect("Failed to read from DB");
 
-    if agents.contains(&req.agent_id) {
-        println!("Agent {} already registered.", req.agent_id);
-        let res = RegisterResponse { status: "exists".to_string(), message: "Agent already registered".to_string() };
+    if registry.iter().any(|agent| agent.agent_id == req.agent_id && agent.status == "active") {
+        println!("Active agent {} already registered.", req.agent_id);
+        let res = RegisterResponse { status: "exists".to_string(), message: "Active agent already registered".to_string() };
         Ok(warp::reply::json(&res))
     } else {
-        agents.push(req.agent_id.clone());
-        write_agents(&agents).expect("Failed to write to DB");
+        let new_agent = AgentInfo {
+            agent_id: req.agent_id.clone(),
+            registered_at: Utc::now().to_rfc3339(),
+            status: "active".to_string(),
+        };
+        registry.push(new_agent);
+        write_registry(&registry).expect("Failed to write to DB");
         println!("Successfully registered agent {}.", req.agent_id);
         let res = RegisterResponse { status: "success".to_string(), message: "Agent successfully registered".to_string() };
         Ok(warp::reply::json(&res))
@@ -58,7 +69,7 @@ async fn handle_registration(req: RegisterRequest, db_lock: Arc<Mutex<()>>) -> R
 
 #[tokio::main]
 async fn main() {
-    println!("KAIRO Seed Node starting...");
+    println!("KAIRO Seed Node [v2: Structured Registry] starting...");
 
     let db_lock = Arc::new(Mutex::new(()));
 
@@ -69,6 +80,6 @@ async fn main() {
         .and_then(handle_registration);
 
     println!("Listening on http://127.0.0.1:8080/register");
-    println!("Registrations will be saved to registered_agents.json");
+    println!("Registrations will be saved to registry.json");
     warp::serve(register).run(([127, 0, 0, 1], 8080)).await;
 }


### PR DESCRIPTION
## Summary
- rewrite `bin/dev/seed_node.rs` to store agent registration details in a structured JSON registry
- track agent id, registration time and status when registering
- update `Cargo.toml` with `chrono` and serde feature for timestamping

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6877f6e035d88333a5558c092ad7a81a