### PR TITLE
Implement ID revocation in seed node

### DIFF
--- a/bin/dev/seed_node.rs
+++ b/bin/dev/seed_node.rs
@@ -67,19 +67,49 @@ async fn handle_registration(req: RegisterRequest, db_lock: Arc<Mutex<()>>) -> R
     }
 }
 
+// Handler for revoking an agent's ID
+async fn handle_revocation(req: RegisterRequest, db_lock: Arc<Mutex<()>>) -> Result<impl Reply, Rejection> {
+    let _lock = db_lock.lock().await;
+    println!("Received revocation request for agent_id: {}", req.agent_id);
+
+    let mut registry = read_registry().expect("Failed to read from DB");
+
+    if let Some(agent) = registry.iter_mut().find(|a| a.agent_id == req.agent_id && a.status == "active") {
+        agent.status = "revoked".to_string();
+        write_registry(&registry).expect("Failed to write to DB");
+        println!("Successfully revoked agent {}.", req.agent_id);
+        let res = RegisterResponse { status: "success".to_string(), message: "Agent successfully revoked".to_string() };
+        Ok(warp::reply::json(&res))
+    } else {
+        println!("Active agent {} not found for revocation.", req.agent_id);
+        let res = RegisterResponse { status: "not_found".to_string(), message: "Active agent not found".to_string() };
+        Ok(warp::reply::json(&res))
+    }
+}
+
 #[tokio::main]
 async fn main() {
     println!("KAIRO Seed Node [v2: Structured Registry] starting...");
 
     let db_lock = Arc::new(Mutex::new(()));
 
+    let register_lock = Arc::clone(&db_lock);
     let register = warp::post()
         .and(warp::path("register"))
         .and(warp::body::json())
-        .and(warp::any().map(move || Arc::clone(&db_lock)))
+        .and(warp::any().map(move || Arc::clone(&register_lock)))
         .and_then(handle_registration);
 
     println!("Listening on http://127.0.0.1:8080/register");
     println!("Registrations will be saved to registry.json");
-    warp::serve(register).run(([127, 0, 0, 1], 8080)).await;
+    let revoke_lock = Arc::clone(&db_lock);
+    let revoke = warp::post()
+        .and(warp::path("revoke"))
+        .and(warp::body::json())
+        .and(warp::any().map(move || Arc::clone(&revoke_lock)))
+        .and_then(handle_revocation);
+
+    let routes = register.or(revoke);
+
+    warp::serve(routes).run(([127, 0, 0, 1], 8080)).await;
 }


### PR DESCRIPTION
## Summary
- support revoking registered agent IDs in `seed_node.rs`
- expose new `/revoke` endpoint alongside registration

## Testing
- `cargo test --all` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6877fb59dc708333aa1ad80e7b5afb6a