### PR TITLE
Implement governance package for seed node

### DIFF
--- a/src/governance.rs
+++ b/src/governance.rs
@@ -1,0 +1,24 @@
+//! src/governance.rs
+//! Defines the structures and protocols for identity sovereignty.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ReissueRequestPayload {
+    pub old_agent_id: String,
+    pub new_agent_id: String,
+    pub reason: String,
+    pub timestamp: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct SignaturePackage {
+    pub signatory_id: String, // ID of the entity signing (Peer AI, Seed Node, Human Auditor)
+    pub signature: String,    // Digital signature of the payload
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct OverridePackage {
+    pub payload: ReissueRequestPayload,
+    pub signatures: Vec<SignaturePackage>,
+}


### PR DESCRIPTION
## Summary
- add governance data structures
- hook governance module into seed node
- provide emergency reissue handler and route

## Testing
- `cargo test` *(fails: failed to download from crates.io)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878103acf688333aa525f8c8dee91a5