### PR TITLE
Fix paths for integration tests

### DIFF
--- a/src/kairo/src/lib.rs
+++ b/src/kairo/src/lib.rs
@@ -1,1 +1,11 @@
 pub mod resolvers;
+
+// Expose internal modules for integration testing
+pub use kairo_rust_core::mesh_auditor;
+pub use kairo_rust_core::mesh_trust_calculator;
+pub use kairo_rust_core::packet_parser;
+pub use kairo_rust_core::baseline_profile_manager;
+pub use kairo_rust_core::signature;
+pub use kairo_rust_core::keygen;
+pub use kairo_rust_core::packet_validator;
+pub use kairo_rust_core::ai_tcp_packet_generated;

--- a/tests/baseline_profile_test.rs
+++ b/tests/baseline_profile_test.rs
@@ -3,7 +3,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::baseline_profile_manager::{BaselineProfileManager, BehaviorProfile};
+    use kairo::baseline_profile_manager::{BaselineProfileManager, BehaviorProfile};
 
     #[test]
     fn test_profile_management() {

--- a/tests/behavior_anomaly_test.rs
+++ b/tests/behavior_anomaly_test.rs
@@ -3,7 +3,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::mesh_trust_calculator::TrustScoreCalculator; // Assuming the struct is in this path
+    use kairo::mesh_trust_calculator::TrustScoreCalculator; // Assuming the struct is in this path
 
     #[test]
     fn test_anomaly_detection_normal_case() {

--- a/tests/diagnosis_integration_test.rs
+++ b/tests/diagnosis_integration_test.rs
@@ -3,8 +3,8 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::mesh_trust_calculator::TrustScoreCalculator;
-    use crate::baseline_profile_manager::{BaselineProfileManager, BehaviorProfile};
+    use kairo::mesh_trust_calculator::TrustScoreCalculator;
+    use kairo::baseline_profile_manager::{BaselineProfileManager, BehaviorProfile};
 
     #[test]
     fn test_behavior_verification_with_profile() {

--- a/tests/mesh_auditor_test.rs
+++ b/tests/mesh_auditor_test.rs
@@ -3,7 +3,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::mesh_auditor::MeshAuditor;
+    use kairo::mesh_auditor::MeshAuditor;
     // Note: To make this test truly effective, we need to allow the auditor to access a mutable manager.
     // This will be addressed in the next refactoring phase.
 

--- a/tests/packet_parser_test.rs
+++ b/tests/packet_parser_test.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::packet_parser::PacketParser; // Updated path
+    use kairo::packet_parser::PacketParser; // Updated path
 
     #[test]
     fn test_parser_instantiation() {


### PR DESCRIPTION
## Summary
- re-export key modules in `kairo` crate
- use `kairo` prefix in integration tests

## Testing
- `cargo test --workspace --no-run` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_68781b5859a48333b3418f86d3d1188f