### PR TITLE
Implement governance structs and emergency reissue route

### DIFF
--- a/kairo-lib/src/governance.rs
+++ b/kairo-lib/src/governance.rs
@@ -1,5 +1,5 @@
-/// src/governance.rs
-/// Defines the structures and protocols for identity sovereignty.
+//! src/governance.rs
+//! Defines the structures and protocols for identity sovereignty.
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
## Summary
- add `governance.rs` module documenting identity sovereignty structs
- import governance structs in dev seed node
- add placeholder handler for emergency reissues and expose an `/emergency_reissue` route

## Testing
- `cargo test --workspace --no-run` *(fails: failed to download index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6879215cbe688333b8fc280afab901c4