### PR TITLE
Add verification stub for emergency reissues

### DIFF
--- a/mesh-node/src/main.rs
+++ b/mesh-node/src/main.rs
@@ -133,11 +133,34 @@ async fn handle_reissue(req: ReissueRequest, db_lock: Arc<Mutex<()>>) -> Result<
     Ok(warp::reply::with_status(warp::reply::json(&res), warp::http::StatusCode::OK))
 }
 
+// --- Signature Verification Logic ---
+// Verifies the signatures in an OverridePackage.
+// NOTE: This is a placeholder. Real implementation requires a cryptographic library and access to public keys.
+fn verify_signatures(req: &OverridePackage) -> bool {
+    println!("Verifying signatures...");
+    if req.signatures.len() < 3 { // Principle of Multiplicity
+        println!("Verification failed: Not enough signatures.");
+        return false;
+    }
+
+    // TODO: Principle of Diversity check (e.g., ensure one signature is from a Seed Node, one from a Peer AI, etc.)
+
+    for sig_package in &req.signatures {
+        // TODO: Implement actual cryptographic verification of sig_package.signature against req.payload
+        println!("Verifying signature from: {}", sig_package.signatory_id);
+    }
+    
+    println!("All signatures passed verification (simulated).");
+    true
+}
+
 // Handler for emergency reissuance by the governance quorum
 async fn handle_emergency_reissue(req: OverridePackage) -> Result<impl warp::Reply, warp::Rejection> {
     println!("Received emergency reissue request.");
-    // TODO: 1. Verify the multiplicity and diversity of signatures.
-    // TODO: 2. Verify each signature against the payload.
+    if !verify_signatures(&req) {
+        let res = RegisterResponse { status: "error".to_string(), message: "Signature verification failed.".to_string() };
+        return Ok(warp::reply::with_status(warp::reply::json(&res), warp::http::StatusCode::UNAUTHORIZED));
+    }
     // TODO: 3. If valid, execute the reissuance logic after a cooldown.
     Ok(warp::reply::json(&"received"))
 }


### PR DESCRIPTION
## Summary
- implement placeholder signature verification in `mesh-node`
- call the verification in the emergency reissue handler

## Testing
- `cargo test --manifest-path rust-core/Cargo.toml --verbose` *(failed: failed to fetch crates)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_687a47053258833383897c42b15d1783