### PR TITLE
Implement quorum diversity check

### DIFF
--- a/kairo-lib/src/governance.rs
+++ b/kairo-lib/src/governance.rs
@@ -13,7 +13,8 @@ pub struct ReissueRequestPayload {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SignaturePackage {
-    pub signatory_id: String, // ID of the entity signing (Peer AI, Seed Node, Human Auditor)
+    pub signatory_id: String, // ID of the entity signing
+    pub signatory_role: String, // Role of the entity: e.g., "PeerAI", "SeedNode", "HumanAuditor"
     pub signature: String,    // Digital signature of the payload
 }
 

--- a/mesh-node/src/main.rs
+++ b/mesh-node/src/main.rs
@@ -138,12 +138,19 @@ async fn handle_reissue(req: ReissueRequest, db_lock: Arc<Mutex<()>>) -> Result<
 // NOTE: This is a placeholder. Real implementation requires a cryptographic library and access to public keys.
 fn verify_signatures(req: &OverridePackage) -> bool {
     println!("Verifying signatures...");
+    use std::collections::HashSet;
+
     if req.signatures.len() < 3 { // Principle of Multiplicity
         println!("Verification failed: Not enough signatures.");
         return false;
     }
 
-    // TODO: Principle of Diversity check (e.g., ensure one signature is from a Seed Node, one from a Peer AI, etc.)
+    // Principle of Diversity Check
+    let roles: HashSet<_> = req.signatures.iter().map(|s| s.signatory_role.clone()).collect();
+    if !roles.contains("PeerAI") || !roles.contains("SeedNode") || !roles.contains("HumanAuditor") {
+        println!("Verification failed: Quorum diversity requirement not met.");
+        return false;
+    }
 
     for sig_package in &req.signatures {
         // TODO: Implement actual cryptographic verification of sig_package.signature against req.payload


### PR DESCRIPTION
## Summary
- extend the `SignaturePackage` struct to include a `signatory_role`
- enforce quorum diversity inside `verify_signatures` using `HashSet`

## Testing
- `cargo test` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_687a49d18fac8333adc4539d455a6035