### PR TITLE
Add KAIRO-P daemon and address request

### DIFF
--- a/bin/daemon/kairo_p_daemon.rs
+++ b/bin/daemon/kairo_p_daemon.rs
@@ -1,0 +1,31 @@
+//! bin/daemon/kairo_p_daemon.rs
+//! The persistent KAIRO-P daemon for address assignment.
+
+use warp::Filter;
+use std::sync::{Arc, Mutex};
+
+// A very simple in-memory address pool for now.
+struct AddressPool {
+    next_address: u8,
+}
+
+#[tokio::main]
+async fn main() {
+    println!("KAIRO-P Daemon starting...");
+
+    let pool = Arc::new(Mutex::new(AddressPool { next_address: 1 }));
+
+    let get_address = warp::post()
+        .and(warp::path("request_address"))
+        .and(warp::any().map(move || Arc::clone(&pool)))
+        .map(|pool: Arc<Mutex<AddressPool>>| {
+            let mut pool = pool.lock().unwrap();
+            let addr = pool.next_address;
+            pool.next_address += 1;
+            println!("Assigned P-Address: 10.0.0.{}", addr);
+            warp::reply::json(&format!("10.0.0.{}", addr))
+        });
+
+    println!("Listening for address requests on http://127.0.0.1:3030");
+    warp::serve(get_address).run(([127, 0, 0, 1], 3030)).await;
+}

--- a/bin/onboard/setup_agent.rs
+++ b/bin/onboard/setup_agent.rs
@@ -26,7 +26,9 @@ fn main() {
         println!("-> Registration failed: {}", e);
     }
 
-    println!("--- KAIRO Mesh Onboarding Complete ---");
+    let p_address = request_p_address();
+    println!("\n--- Onboarding Complete ---");
+    println!("Your assigned KAIRO-P Address: {}", p_address);
 }
 
 // シードノードへの登録を行う関数
@@ -47,4 +49,20 @@ fn register_with_seed_node(public_key: &str) -> Result<(), reqwest::Error> {
     }
 
     Ok(())
+}
+
+fn request_p_address() -> String {
+    println!("\nRequesting KAIRO-P address from local daemon...");
+    let client = reqwest::blocking::Client::new();
+    match client.post("http://localhost:3030/request_address").send() {
+        Ok(res) => {
+            let addr = res.json::<String>().unwrap_or_else(|_| "error".to_string());
+            println!("-> KAIRO-P Address assigned: {}", addr);
+            addr
+        },
+        Err(e) => {
+            println!("-> Failed to connect to KAIRO-P daemon: {}. Is it running?", e);
+            "failed_to_connect".to_string()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a minimal KAIRO-P address daemon
- request a P address during onboarding

## Testing
- `cargo test` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a4b6506a88333b87f9678ec3c2b4f