### PR TITLE
Fix variable name for agent config

### DIFF
--- a/bin/onboard/setup_agent.rs
+++ b/bin/onboard/setup_agent.rs
@@ -10,8 +10,8 @@ use config::{load_config, save_config, AgentConfig};
 fn main() {
     if let Some(config) = load_config() {
         // If config was loaded, attempt registration with the existing public key
-        if let Some(config) = &config {
-            register_with_seed_node(&config.public_key);
+        if let Some(agent_config) = &config {
+            register_with_seed_node(&agent_config.public_key);
         }
         // If config was loaded, attempt registration with the existing public key
         register_with_seed_node(&config.public_key);


### PR DESCRIPTION
## Summary
- fix variable name shadowing bug in setup_agent

## Testing
- `cargo test --quiet --offline` *(fails: no matching package named `flatbuffers` found)*

------
https://chatgpt.com/codex/tasks/task_e_687a678a1c24833390dc10d624c20df7