### PR TITLE
Add --new flag to setup_agent

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -8,6 +8,8 @@ ed25519-dalek = "2"
 rand_core = "0.6"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
+hex = "0.4"
 
 [[bin]]
 name = "setup_agent"

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -1,33 +1,42 @@
-//! bin/onboard/config.rs
-//! Handles loading and saving of the agent's identity.
+//! src/agent/config.rs
+//! Handles loading and saving of agent identities.
 
 use serde::{Deserialize, Serialize};
-use std::fs::{File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{BufReader, BufWriter};
+use std::path::Path;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AgentConfig {
     pub p_address: String,
     pub public_key: String,
     pub secret_key: String,
 }
 
-const CONFIG_FILE: &str = "agent_config.json";
+const CONFIG_DIR: &str = "agent_configs";
 
 pub fn save_config(config: &AgentConfig) -> Result<(), std::io::Error> {
-    let file = OpenOptions::new().write(true).create(true).truncate(true).open(CONFIG_FILE)?;
+    fs::create_dir_all(CONFIG_DIR)?;
+    let config_path = Path::new(CONFIG_DIR).join(format!("{}.json", config.p_address));
+    let file = OpenOptions::new().write(true).create(true).truncate(true).open(config_path)?;
     let writer = BufWriter::new(file);
     serde_json::to_writer_pretty(writer, config)?;
-    println!("-> Agent configuration saved to {}", CONFIG_FILE);
+    println!("-> Agent configuration saved.");
     Ok(())
 }
 
-pub fn load_config() -> Option<AgentConfig> {
-    if let Ok(file) = File::open(CONFIG_FILE) {
-        let reader = BufReader::new(file);
-        if let Ok(config) = serde_json::from_reader(reader) {
-            println!("-> Agent configuration loaded from {}", CONFIG_FILE);
-            return Some(config);
+/// Loads the first available agent config.
+/// In a real application multiple identities would be handled.
+pub fn load_first_config() -> Option<AgentConfig> {
+    if let Ok(entries) = fs::read_dir(CONFIG_DIR) {
+        for entry in entries.flatten() {
+            if let Ok(file) = File::open(entry.path()) {
+                let reader = BufReader::new(file);
+                if let Ok(config) = serde_json::from_reader(reader) {
+                    println!("-> Loaded first available agent configuration.");
+                    return Some(config);
+                }
+            }
         }
     }
     None

--- a/src/agent/setup_agent.rs
+++ b/src/agent/setup_agent.rs
@@ -1,18 +1,31 @@
+use clap::Parser;
+use ed25519_dalek::{SigningKey, SECRET_KEY_LENGTH};
+use rand_core::{OsRng, RngCore};
 use serde::Deserialize;
+
+mod config;
+use config::{load_first_config, save_config, AgentConfig};
+
+#[derive(Parser)]
+#[command(name = "setup_agent", about = "KAIRO Agent Setup Utility")]
+struct Args {
+    /// Force creation of a brand new agent configuration
+    #[arg(short, long)]
+    new: bool,
+}
 
 #[derive(Deserialize)]
 struct AddressResponse {
     p_address: String,
 }
 
-// Pアドレスの要求を行う関数
 fn request_p_address() -> String {
     println!("\nRequesting KAIRO-P address from local daemon...");
     let client = reqwest::blocking::Client::new();
-
     match client.post("http://localhost:3030/request_address").send() {
         Ok(res) => {
-            let addr = res.json::<AddressResponse>()
+            let addr = res
+                .json::<AddressResponse>()
                 .map(|r| r.p_address)
                 .unwrap_or_else(|_| "error".to_string());
             println!("-> KAIRO-P Address assigned: {}", addr);
@@ -25,6 +38,68 @@ fn request_p_address() -> String {
     }
 }
 
+fn register_with_seed_node(public_key: &str) -> Result<(), reqwest::Error> {
+    println!("-> Attempting to register public key with seed node...");
+    let seed_node_url = "http://localhost:8080/register";
+
+    let mut payload = std::collections::HashMap::new();
+    payload.insert("agent_id", public_key);
+
+    let client = reqwest::blocking::Client::new();
+    let res = client.post(seed_node_url).json(&payload).send()?;
+
+    if res.status().is_success() {
+        println!("-> Successfully registered with seed node.");
+    } else {
+        println!("-> Failed to register. Status: {}", res.status());
+    }
+
+    Ok(())
+}
+
 fn main() {
-    let _ = request_p_address();
+    let args = Args::parse();
+
+    if !args.new {
+        if let Some(config) = load_first_config() {
+            // Attempt registration with existing public key
+            let _ = register_with_seed_node(&config.public_key);
+            println!("\n--- Welcome Back ---");
+            println!("Restored identity from configuration");
+            println!("Your KAIRO-P Address: {}", config.p_address);
+            println!("Your Public Key: {}", config.public_key);
+            return;
+        }
+    } else {
+        println!("[NEW AGENT MODE]");
+    }
+
+    println!("--- KAIRO Mesh Initial Setup ---");
+
+    let mut csprng = OsRng;
+    let mut secret_bytes = [0u8; SECRET_KEY_LENGTH];
+    csprng.fill_bytes(&mut secret_bytes);
+
+    let signing_key = SigningKey::from_bytes(&secret_bytes);
+    let verifying_key = signing_key.verifying_key();
+
+    let private_key_hex = hex::encode(signing_key.to_bytes());
+    let public_key_hex = hex::encode(verifying_key.to_bytes());
+
+    println!("Secret Key: {:?}", private_key_hex);
+    println!("Public Key: {:?}", public_key_hex);
+
+    println!("\nStep 2: Registering with a Seed Node...");
+
+    let p_address = request_p_address();
+    let config = AgentConfig {
+        p_address: p_address.clone(),
+        public_key: public_key_hex,
+        secret_key: private_key_hex,
+    };
+
+    let _ = register_with_seed_node(&config.public_key);
+    save_config(&config).expect("Failed to save agent configuration.");
+    println!("\n--- Onboarding Complete ---");
+    println!("Your assigned KAIRO-P Address: {}", p_address);
 }


### PR DESCRIPTION
## Summary
- support multi-agent config loading in `kairo_agent`
- implement `--new`/`-n` flag in `setup_agent`
- regenerate keys and P address when forced
- log `[NEW AGENT MODE]`

## Testing
- `cargo fmt --all` *(fails: rustfmt component missing)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_687aaf81dba88333af6ea8270361b41d