### PR TITLE
Implement message persistence for daemon

### DIFF
--- a/src/kairo-daemon/Cargo.toml
+++ b/src/kairo-daemon/Cargo.toml
@@ -9,7 +9,7 @@ tokio = { version = "1", features = ["full"] }
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-uuid = { version = "1", features = ["v4"] }   # ← 使わなければ省略可
+kairo_lib = { path = "../kairo-lib" }
 
 [[bin]]
 name = "kairo_p_daemon"

--- a/src/kairo-daemon/kairo_p_daemon.rs
+++ b/src/kairo-daemon/kairo_p_daemon.rs
@@ -2,46 +2,96 @@ use std::collections::{HashMap, VecDeque};
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::fs::{self, File, OpenOptions};
+use std::io::BufReader;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+use serde_json::{self, json};
 use warp::Filter;
 
+use kairo_lib::packet::AiTcpPacket;
+
+const STORE_DIR: &str = "message_store";
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct Agent {
     p_address: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-struct Message {
-    from_p_address: String,
-    to_p_address: String,
-    payload: String,
+type AgentList = Arc<Mutex<HashMap<String, Agent>>>;
+type MessageQueues = Arc<Mutex<HashMap<String, VecDeque<AiTcpPacket>>>>;
+
+fn load_persistent_messages(queues: &MessageQueues) {
+    if !Path::new(STORE_DIR).exists() {
+        if let Err(e) = fs::create_dir_all(STORE_DIR) {
+            eprintln!("Failed to create message store directory: {}", e);
+            return;
+        }
+    }
+
+    if let Ok(entries) = fs::read_dir(STORE_DIR) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("json") {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    if let Ok(file) = File::open(&path) {
+                        let reader = BufReader::new(file);
+                        if let Ok(messages) = serde_json::from_reader::<_, Vec<AiTcpPacket>>(reader) {
+                            let mut lock = queues.lock().unwrap();
+                            lock.insert(stem.to_string(), VecDeque::from(messages));
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
-type AgentList = Arc<Mutex<HashMap<String, Agent>>>;
-type MessageBuffer = Arc<Mutex<HashMap<String, VecDeque<Message>>>>;
+fn persist_queue(p_address: &str, queue: &VecDeque<AiTcpPacket>) {
+    if !Path::new(STORE_DIR).exists() {
+        if let Err(e) = fs::create_dir_all(STORE_DIR) {
+            eprintln!("Failed to create message store directory: {}", e);
+            return;
+        }
+    }
+
+    let path = format!("{}/{}.json", STORE_DIR, p_address);
+    if let Ok(file) = OpenOptions::new().write(true).truncate(true).create(true).open(&path) {
+        if let Err(e) = serde_json::to_writer_pretty(&file, &queue.iter().cloned().collect::<Vec<_>>()) {
+            eprintln!("Failed to write message store for {}: {}", p_address, e);
+        }
+    } else {
+        eprintln!("Failed to open message store file for {}", p_address);
+    }
+}
 
 #[tokio::main]
 async fn main() {
     println!("KAIRO-P Daemon starting...");
 
     let agent_list: AgentList = Arc::new(Mutex::new(HashMap::new()));
-    let message_buffer: MessageBuffer = Arc::new(Mutex::new(HashMap::new()));
+    let message_queues: MessageQueues = Arc::new(Mutex::new(HashMap::new()));
+    load_persistent_messages(&message_queues);
 
     let get_address = warp::path("request_address")
         .and(warp::get())
         .and(with_agent_list(agent_list.clone()))
-        .and(with_message_buffer(message_buffer.clone()))
+        .and(with_message_queues(message_queues.clone()))
         .and_then(assign_p_address);
+
+    let send_message = warp::path("send")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_message_queues(message_queues.clone()))
+        .and_then(handle_send);
 
     let receive_message = warp::path("receive")
         .and(warp::post())
         .and(warp::body::json())
-        .and(with_message_buffer(message_buffer.clone()))
+        .and(with_message_queues(message_queues.clone()))
         .and_then(handle_receive);
 
-    let routes = get_address.or(receive_message);
+    let routes = get_address.or(send_message).or(receive_message);
 
     let addr: SocketAddr = ([127, 0, 0, 1], 3030).into();
     warp::serve(routes).run(addr).await;
@@ -53,15 +103,15 @@ fn with_agent_list(
     warp::any().map(move || agent_list.clone())
 }
 
-fn with_message_buffer(
-    buffer: MessageBuffer,
-) -> impl Filter<Extract = (MessageBuffer,), Error = Infallible> + Clone {
+fn with_message_queues(
+    buffer: MessageQueues,
+) -> impl Filter<Extract = (MessageQueues,), Error = Infallible> + Clone {
     warp::any().map(move || buffer.clone())
 }
 
 async fn assign_p_address(
     agent_list: AgentList,
-    buffer: MessageBuffer,
+    buffer: MessageQueues,
 ) -> Result<impl warp::Reply, Infallible> {
     let mut agents = agent_list.lock().unwrap();
     let mut counter = 1;
@@ -85,6 +135,21 @@ async fn assign_p_address(
     Ok(warp::reply::json(&agent))
 }
 
+async fn handle_send(
+    packet: AiTcpPacket,
+    buffer: MessageQueues,
+) -> Result<impl warp::Reply, Infallible> {
+    {
+        let mut buffers = buffer.lock().unwrap();
+        let queue = buffers
+            .entry(packet.destination_p_address.clone())
+            .or_insert_with(VecDeque::new);
+        queue.push_back(packet.clone());
+        persist_queue(&packet.destination_p_address, queue);
+    }
+    Ok(warp::reply::json(&serde_json::json!({ "status": "queued" })))
+}
+
 #[derive(Debug, Deserialize)]
 struct ReceiveRequest {
     p_address: String,
@@ -92,11 +157,12 @@ struct ReceiveRequest {
 
 async fn handle_receive(
     req: ReceiveRequest,
-    buffer: MessageBuffer,
+    buffer: MessageQueues,
 ) -> Result<impl warp::Reply, Infallible> {
     let mut buffers = buffer.lock().unwrap();
     if let Some(queue) = buffers.get_mut(&req.p_address) {
         if let Some(message) = queue.pop_front() {
+            persist_queue(&req.p_address, queue);
             return Ok(warp::reply::json(&message));
         }
     }


### PR DESCRIPTION
## Summary
- add message persistence to `kairo_p_daemon`
- store packets per destination P-address in `message_store`
- reload messages on startup and update files on send/receive
- depend on `kairo_lib` for `AiTcpPacket`

## Testing
- `cargo build -p kairo_daemon` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ab01a42988333b153fa9de1c5ecd5