### PR TITLE
Add signed sender example and update packet struct

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -14,3 +14,7 @@ hex = "0.4"
 [[bin]]
 name = "setup_agent"
 path = "setup_agent.rs"
+
+[[bin]]
+name = "signed_sender"
+path = "signed_sender.rs"

--- a/src/agent/signed_sender.rs
+++ b/src/agent/signed_sender.rs
@@ -1,0 +1,54 @@
+// 署名付きパケット送信クライアント
+use kairo_lib::packet::AiTcpPacket;
+use ed25519_dalek::{SigningKey, Signature, Signer};
+use std::fs::File;
+use std::io::Read;
+use chrono::Utc;
+use reqwest::blocking::Client;
+use serde::{Serialize, Deserialize};
+use std::collections::HashMap;
+use std::path::Path;
+use hex;
+
+#[derive(Serialize, Deserialize)]
+struct AgentConfig {
+    pub p_address: String,
+    pub secret_key: String,
+    pub public_key: String,
+}
+
+fn main() {
+    // agent_config.jsonの読み込み
+    let path = Path::new("agent_configs/agent_config_1.json");
+    let mut file = File::open(path).expect("Failed to open config");
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+    let config: AgentConfig = serde_json::from_str(&contents).unwrap();
+
+    let payload = "signed hello";
+    let payload_bytes = payload.as_bytes();
+
+    let secret_bytes = hex::decode(&config.secret_key).unwrap();
+    let signing_key = SigningKey::from_bytes(&secret_bytes.try_into().unwrap());
+    let signature: Signature = signing_key.sign(payload_bytes);
+    let signature_hex = hex::encode(signature.to_bytes());
+
+    let packet = AiTcpPacket {
+        version: 1,
+        source_p_address: config.p_address.clone(),
+        destination_p_address: "10.0.0.2".to_string(),
+        sequence: 1,
+        timestamp: Utc::now().timestamp(),
+        payload_type: "text".to_string(),
+        payload: payload.to_string(),
+        signature: signature_hex,
+    };
+
+    let client = Client::new();
+    let res = client.post("http://127.0.0.1:3030/send")
+        .json(&packet)
+        .send()
+        .expect("Request failed");
+
+    println!("Send result: {}", res.status());
+}

--- a/src/kairo-lib/src/packet.rs
+++ b/src/kairo-lib/src/packet.rs
@@ -12,4 +12,5 @@ pub struct AiTcpPacket {
     pub timestamp: i64,
     pub payload_type: String, // e.g., "text/plain", "application/json"
     pub payload: String,
+    pub signature: String,
 }

--- a/src/mesh-node/main.rs
+++ b/src/mesh-node/main.rs
@@ -55,3 +55,5 @@ async fn main() {
 
     warp::serve(routes).run(([127, 0, 0, 1], 8082)).await;
 }
+
+// ここに実際のWarpエンドポイントのテストコードを追加する（内容省略）


### PR DESCRIPTION
## Summary
- implement a `signed_sender` binary for agents
- register the binary in the agent crate
- extend `AiTcpPacket` with a signature field
- note placeholder test comment in `mesh-node`

## Testing
- `cargo build --all` *(fails: failed to download index due to network restrictions)*
- `cargo run --bin kairo_p_daemon` *(fails: could not fetch crates)*
- `cargo run --bin setup_agent --manifest-path src/agent/Cargo.toml` *(fails: could not fetch crates)*
- `cargo run --bin signed_sender --manifest-path src/agent/Cargo.toml` *(fails: could not fetch crates)*
- `curl -X POST http://127.0.0.1:3030/receive -H "Content-Type: application/json" -d '{"p_address":"10.0.0.2"}'` *(fails: connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_687ab33293b483339bfe60ce482cd485