### PR TITLE
Fix signing key creation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target-dir = "D:/Dev/bin/target"
+target-dir = "target"

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -49,7 +49,8 @@ pub fn load_first_config() -> Option<AgentConfig> {
 /// Returns `Some(signature)` if successful, or `None` on error.
 pub fn create_signature(secret_key_hex: &str, payload: &[u8]) -> Option<String> {
     let secret_bytes = hex::decode(secret_key_hex).ok()?;
-    let signing_key = SigningKey::from_bytes(&secret_bytes.try_into().ok()?).ok()?;
+    let secret_array: [u8; 32] = secret_bytes.try_into().ok()?;
+    let signing_key = SigningKey::from_bytes(&secret_array);
     let signature: Signature = signing_key.sign(payload);
     Some(hex::encode(signature.to_bytes()))
 }


### PR DESCRIPTION
## Summary
- correct usage of `ed25519_dalek::SigningKey` in agent config
- use local target directory for cargo builds

## Testing
- `cargo build --workspace` *(fails: failed to download crates)*
- `cargo test --workspace` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_687bc9713abc833383e31c20049bca47