### PR TITLE
Implement self-signed agent config

### DIFF
--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -6,7 +6,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
-use ed25519_dalek::{SigningKey, Signature, Signer};
+use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey, Signature};
 use hex;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -14,9 +14,39 @@ pub struct AgentConfig {
     pub p_address: String,
     pub public_key: String,
     pub secret_key: String,
+    pub signature: String, // Signature of p_address + public_key
 }
 
 const CONFIG_DIR: &str = "agent_configs";
+
+// Creates a signature for the config file to ensure its integrity.
+pub fn create_signature(p_address: &str, public_key: &str, secret_key: &SigningKey) -> String {
+    let message = format!("{}:{}", p_address, public_key);
+    let signature = secret_key.sign(message.as_bytes());
+    hex::encode(signature.to_bytes())
+}
+
+// Verifies the signature within the config file.
+fn verify_signature(config: &AgentConfig) -> bool {
+    let public_key_bytes = match hex::decode(&config.public_key) {
+        Ok(bytes) => bytes,
+        Err(_) => return false,
+    };
+    let public_key = match VerifyingKey::from_bytes(&public_key_bytes) {
+        Ok(key) => key,
+        Err(_) => return false,
+    };
+    let signature_bytes = match hex::decode(&config.signature) {
+        Ok(bytes) => bytes,
+        Err(_) => return false,
+    };
+    let signature = match Signature::from_bytes(&signature_bytes) {
+        Ok(sig) => sig,
+        Err(_) => return false,
+    };
+    let message = format!("{}:{}", config.p_address, config.public_key);
+    public_key.verify(message.as_bytes(), &signature).is_ok()
+}
 
 pub fn save_config(config: &AgentConfig) -> Result<(), std::io::Error> {
     fs::create_dir_all(CONFIG_DIR)?;
@@ -35,9 +65,14 @@ pub fn load_first_config() -> Option<AgentConfig> {
         for entry in entries.flatten() {
             if let Ok(file) = File::open(entry.path()) {
                 let reader = BufReader::new(file);
-                if let Ok(config) = serde_json::from_reader(reader) {
-                    println!("-> Loaded first available agent configuration.");
-                    return Some(config);
+                if let Ok(config): Result<AgentConfig, _> = serde_json::from_reader(reader) {
+                    if verify_signature(&config) {
+                        println!("-> Agent configuration integrity VERIFIED.");
+                        return Some(config);
+                    } else {
+                        println!("CRITICAL: Agent configuration has been TAMPERED WITH. Loading aborted.");
+                        return None;
+                    }
                 }
             }
         }
@@ -45,12 +80,3 @@ pub fn load_first_config() -> Option<AgentConfig> {
     None
 }
 
-/// Creates a hex-encoded signature from the given secret key and payload.
-/// Returns `Some(signature)` if successful, or `None` on error.
-pub fn create_signature(secret_key_hex: &str, payload: &[u8]) -> Option<String> {
-    let secret_bytes = hex::decode(secret_key_hex).ok()?;
-    let secret_array: [u8; 32] = secret_bytes.try_into().ok()?;
-    let signing_key = SigningKey::from_bytes(&secret_array);
-    let signature: Signature = signing_key.sign(payload);
-    Some(hex::encode(signature.to_bytes()))
-}

--- a/src/agent/setup_agent.rs
+++ b/src/agent/setup_agent.rs
@@ -4,7 +4,7 @@ use ed25519_dalek::{SigningKey, SECRET_KEY_LENGTH};
 use rand_core::{OsRng, RngCore};
 
 pub mod config;
-use config::{load_first_config, save_config, AgentConfig};
+use config::{load_first_config, save_config, AgentConfig, create_signature};
 
 fn main() {
     // 既存のエージェント構成が存在する場合はロード
@@ -37,10 +37,13 @@ fn main() {
     // PアドレスをKAIRO-Pデーモンから取得
     let p_address = request_p_address();
 
+    let signature = create_signature(&p_address, &public_key_hex, &signing_key);
+
     let config = AgentConfig {
         p_address: p_address.clone(),
         public_key: public_key_hex,
         secret_key: private_key_hex,
+        signature,
     };
 
     register_with_seed_node(&config.public_key).ok();


### PR DESCRIPTION
## Summary
- extend `AgentConfig` with a `signature` field
- add helpers to sign and verify config files
- verify signature when loading configuration
- record signature when creating a config during setup

## Testing
- `cargo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bcb46ec308333bc569293c37fed35