### PR TITLE
Fix library exports

### DIFF
--- a/src/kairo-lib/src/lib.rs
+++ b/src/kairo-lib/src/lib.rs
@@ -1,0 +1,12 @@
+//! src/kairo-lib/src/lib.rs
+
+// Publicly export all essential modules for external crates like kairo-server.
+
+pub mod config;
+pub mod governance;
+pub mod packet;
+
+// Re-export key data structures for easier access.
+pub use config::AgentConfig;
+pub use governance::OverridePackage;
+pub use packet::AiTcpPacket;


### PR DESCRIPTION
## Summary
- add src layout for `kairo-lib`
- publicly re-export core components for external crates

## Testing
- `cargo test` *(fails: failed to load manifest for dependency `kairo_core`)*

------
https://chatgpt.com/codex/tasks/task_e_687bec08ee188333852cab735f8b2950