### PR TITLE
Add forged sender tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ cargo run --package kairo_agent --bin signed_sender -- --to $agent2_p_address --
 
 -   **期待されるサーバーログ:** `kairo_p_daemon`のログに `Signature FAILED` および `Packet REJECTED` と表示され、メッセージがキューイングされないことを確認します。
 
+#### 3.3. Pアドレス偽装テスト
+
+`forged_sender` を使うと、`agent_config.json` の鍵で署名しつつ任意のPアドレスを送信元として指定できます。
+
+```powershell
+# PowerShellでの実行例
+cargo run --package kairo_agent --bin forged_sender -- --to $agent2_p_address --from "p-fakeaddress" --message "spoof test"
+```
+
+-   **期待されるサーバーログ:** 送信元Pアドレスが登録済みでないため `Signature Fail: Source agent not found.` が表示されます。
+
 ---
 
 ### 🏗️ 4. 現在の開発ステータス

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -33,3 +33,7 @@ path = "send_message.rs"
 [[bin]]
 name = "receive_signed"
 path = "receive_signed.rs"
+
+[[bin]]
+name = "forged_sender"
+path = "forged_sender.rs"

--- a/src/agent/forged_sender.rs
+++ b/src/agent/forged_sender.rs
@@ -1,0 +1,82 @@
+// forged_sender.rs - Send signed packet with spoofed P address for testing
+
+use ed25519_dalek::{Signer, SigningKey, Signature};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use clap::Parser;
+use reqwest::blocking::Client;
+use hex;
+
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Args {
+    /// Destination P address
+    #[arg(long)]
+    to: String,
+
+    /// Message body
+    #[arg(long)]
+    message: String,
+
+    /// Spoofed source P address
+    #[arg(long)]
+    from: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct AgentConfig {
+    p_address: String,
+    public_key: String,
+    secret_key: String,
+    signature: String,
+}
+
+#[derive(Serialize, Debug)]
+struct AiTcpPacket {
+    source_p_address: String,
+    destination_p_address: String,
+    payload: String,
+    signature: String,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let config_path = PathBuf::from("agent_config.json");
+    let config_data = fs::read_to_string(config_path)?;
+    let config: AgentConfig = serde_json::from_str(&config_data)?;
+
+    let signing_key_bytes = hex::decode(&config.secret_key)?;
+    let key_bytes: [u8; 32] = signing_key_bytes
+        .try_into()
+        .map_err(|_| "Invalid key length")?;
+    let signing_key = SigningKey::from_bytes(&key_bytes);
+
+    let signature: Signature = signing_key.sign(args.message.as_bytes());
+    let signature_hex = hex::encode(signature.to_bytes());
+
+    let packet = AiTcpPacket {
+        source_p_address: args.from,
+        destination_p_address: args.to,
+        payload: args.message,
+        signature: signature_hex,
+    };
+
+    println!("{:#?}", serde_json::to_string(&packet)?);
+
+    let client = Client::new();
+    let res = client
+        .post("http://127.0.0.1:3030/send")
+        .json(&packet)
+        .send()?;
+
+    if res.status().is_success() {
+        println!("✅ Packet sent successfully.");
+    } else {
+        println!("❌ Failed to send packet: {}", res.status());
+    }
+
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- add `forged_sender` binary to send spoofed packets
- document how to use `forged_sender`

## Testing
- `cargo test --all --no-run` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_687c27a20dd88333901f0a08aafe608f