### PR TITLE
Add KairoCIO I/O spec module

### DIFF
--- a/src/kairo_lib/src/cio.rs
+++ b/src/kairo_lib/src/cio.rs
@@ -1,0 +1,27 @@
+// KAIRO-CIO I/O Spec
+#[derive(Debug, Clone)]
+pub struct KairoCIO {
+    pub input_channels: Vec<String>,
+    pub output_channels: Vec<String>,
+    pub max_bandwidth_per_channel: u32,
+    pub io_mode: IOMode,
+}
+
+#[derive(Debug, Clone)]
+pub enum IOMode {
+    Interrupt,
+    Polling,
+    Hybrid,
+}
+
+impl KairoCIO {
+    pub fn describe(&self) -> String {
+        format!(
+            "Inputs: {} / Outputs: {} / Mode: {:?} / Bandwidth: {}kbps",
+            self.input_channels.len(),
+            self.output_channels.len(),
+            self.io_mode,
+            self.max_bandwidth_per_channel
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add new `src/kairo_lib/src/cio.rs` containing the KairoCIO struct and its IOMode enum

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883ba4f7c048333b7d3114d95356229