### PR TITLE
Add zoning protocol enum

### DIFF
--- a/src/kairo_lib/src/zoning.rs
+++ b/src/kairo_lib/src/zoning.rs
@@ -1,0 +1,20 @@
+// Zoning Protocol structure
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Zone {
+    Public,
+    Sensitive,
+    Restricted,
+    Experimental,
+}
+
+impl Zone {
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label.to_lowercase().as_str() {
+            "public" => Some(Self::Public),
+            "sensitive" => Some(Self::Sensitive),
+            "restricted" => Some(Self::Restricted),
+            "experimental" => Some(Self::Experimental),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add zoning enum for protocol in the new `kairo_lib` module

## Testing
- `cargo test --manifest-path rust-core/Cargo.toml --verbose` *(fails: failed to download from crates.io)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src.errors')*
- `python scripts/validate_logs.py --check vov/example_log.jsonl`

------
https://chatgpt.com/codex/tasks/task_e_6883ba1e94dc833382ec025a0cdca73f