### PR TITLE
Add agent config generator and CLI config option

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -38,3 +38,7 @@ path = "receive_signed.rs"
 name = "forged_sender"
 path = "forged_sender.rs"
 
+[[bin]]
+name = "agent_config_gen"
+path = "agent_config_gen.rs"
+

--- a/src/agent/agent_config_gen.rs
+++ b/src/agent/agent_config_gen.rs
@@ -1,0 +1,34 @@
+// 自動 agent_config.json 生成ツール
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use serde::{Serialize};
+use std::{fs, env};
+use hex;
+
+#[derive(Serialize)]
+struct AgentConfig {
+    public_key: String,
+    secret_key: String,
+    signature: String,
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <agent_name>", args[0]);
+        return;
+    }
+    let name = &args[1];
+    let signing_key = SigningKey::generate(&mut rand::rngs::OsRng);
+    let verifying_key: VerifyingKey = signing_key.verifying_key();
+
+    let config = AgentConfig {
+        public_key: hex::encode(verifying_key.to_bytes()),
+        secret_key: hex::encode(signing_key.to_bytes()),
+        signature: "".to_string()
+    };
+
+    let path = format!("{}_config.json", name);
+    let json = serde_json::to_string_pretty(&config).unwrap();
+    fs::write(&path, json).unwrap();
+    println!("✅ {} written", path);
+}

--- a/src/agent/signed_sender.rs
+++ b/src/agent/signed_sender.rs
@@ -24,6 +24,9 @@ struct Args {
 
     #[arg(long, default_value_t = false)]
     fake: bool,
+
+    #[arg(long, default_value = "agent_config.json")]
+    config: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -60,7 +63,7 @@ fn get_daemon_url() -> String {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    let config_path = PathBuf::from("agent_config.json");
+    let config_path = PathBuf::from(&args.config);
     let config_data = fs::read_to_string(config_path)?;
     let config: AgentConfig = serde_json::from_str(&config_data)?;
 


### PR DESCRIPTION
## Summary
- extend `signed_sender` arguments to allow custom config file
- load config from the new `--config` CLI option
- add `agent_config_gen` binary for creating agent config files
- register new binary in `kairo_agent`'s `Cargo.toml`

## Testing
- `cargo test -p kairo_agent` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883c007895483338f001d076b984829