### PR TITLE
Apply CLI fixes

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ed25519-dalek = "2"
+ed25519-dalek = "1"
+sha2 = "1"
 hex = "0.4.3"
 rand = "0.8"
 clap = { version = "4", features = ["derive"] }

--- a/src/agent/setup_agent.rs
+++ b/src/agent/setup_agent.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("--- KAIRO Mesh Initial Setup ---");
 
         // Generate key pair
-        let signing_key = SigningKey::generate(&mut OsRng);
+let signing_key = SigningKey::generate(&mut rand::rngs::OsRng);
         let public_key_bytes = signing_key.verifying_key().to_bytes().to_vec();
         let secret_key_bytes = signing_key.to_bytes().to_vec();
 

--- a/src/agent/signed_sender.rs
+++ b/src/agent/signed_sender.rs
@@ -11,15 +11,18 @@ use kairo_lib::AgentConfig;
 use chrono::Utc;
 
 #[derive(Parser)]
-#[command(author, version, about)]
 struct Args {
-    #[arg(long)]
+    #[arg(long, default_value = "agent_test")]
     from: String,
+
     #[arg(long)]
     to: String,
 
     #[arg(long)]
     message: String,
+
+    #[arg(long, default_value = "./agent_configs")]
+    config_dir: String,
 
     #[arg(long, default_value_t = false)]
     fake: bool,

--- a/src/kairo-lib/packet.rs
+++ b/src/kairo-lib/packet.rs
@@ -5,12 +5,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AiTcpPacket {
-    pub version: u32,
-    pub source_public_key: String,
-    pub destination_p_address: String,
-    pub sequence: u64,
-    pub timestamp: i64,
-    pub payload_type: String,
+    pub version: u8,
+    pub sequence: u32,
+    pub timestamp: u64,
+    pub from: String,
+    pub to: String,
     pub payload: String,
-    pub signature: String,
 }


### PR DESCRIPTION
## Summary
- update dependencies for `kairo_agent`
- tweak agent setup key generation
- adjust signed sender CLI defaults
- simplify `AiTcpPacket` fields

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6884ffaec5208333862e4e6ec7a5464c