### PR TITLE
Update daemon for signature verification

### DIFF
--- a/src/kairo-daemon/Cargo.toml
+++ b/src/kairo-daemon/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+ed25519-dalek = "1"
+sha2 = "1"
+serde_json = "1"
 warp = "0.3"
 tokio = { version = "1", features = ["full"] }
 once_cell = "1.19"


### PR DESCRIPTION
## Summary
- include crypto deps in `kairo-daemon`
- add application state and signature-verifying `handle_send`

## Testing
- `cargo check -p kairo_daemon` *(fails: failed to download index)*

------
https://chatgpt.com/codex/tasks/task_e_68850cbfd2f88333a75f2b3d4fcc0bf5