### PR TITLE
Update key generation in agent setup

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 ed25519-dalek = "1"
+rand = "0.8"
 sha2 = "1"
 hex = "0.4.3"
-rand = "0.8"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.141"

--- a/src/agent/setup_agent.rs
+++ b/src/agent/setup_agent.rs
@@ -1,5 +1,6 @@
 use kairo_lib::{save_agent_config};
 use ed25519_dalek::SigningKey;
+use rand::RngCore;
 use rand::rngs::OsRng;
 use reqwest;
 use serde::Deserialize;
@@ -52,7 +53,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("--- KAIRO Mesh Initial Setup ---");
 
         // Generate key pair
-let signing_key = SigningKey::generate(&mut rand::rngs::OsRng);
+        let mut csprng = OsRng;
+        let mut sk_bytes = [0u8; 32];
+        csprng.fill_bytes(&mut sk_bytes);
+        let signing_key = SigningKey::from_bytes(&sk_bytes).unwrap();
         let public_key_bytes = signing_key.verifying_key().to_bytes().to_vec();
         let secret_key_bytes = signing_key.to_bytes().to_vec();
 


### PR DESCRIPTION
## Summary
- add `rand` crate to agent
- use `OsRng` directly for generating signing key

## Testing
- `cargo check` *(fails: duplicate key `serde_json` in `src/kairo-daemon/Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_68851c0fc6148333a8b242be72d2acf3