### PR TITLE
Resolve merge conflicts in agent setup key generation

### DIFF
--- a/src/agent/setup_agent.rs
+++ b/src/agent/setup_agent.rs
@@ -55,6 +55,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("--- KAIRO Mesh Initial Setup ---");
 
 // Generate key pair
+        use rand::RngCore;
+use rand::rngs::OsRng;
         let mut csprng = OsRng;
         let mut sk_bytes = [0u8; 32];
         csprng.fill_bytes(&mut sk_bytes);


### PR DESCRIPTION
## Summary
- update key generation snippet in `setup_agent.rs`

## Testing
- `cargo check --workspace` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6885204d5c988333b22155697a506115