### PR TITLE
Improve packet validator logging and tests

### DIFF
--- a/rust-core/src/packet_validator.rs
+++ b/rust-core/src/packet_validator.rs
@@ -7,6 +7,25 @@ use crate::ai_tcp_packet_generated::aitcp as fb;
 use crate::signature::verify_ed25519;
 use ed25519_dalek::{Signature as Ed25519Signature, VerifyingKey};
 
+/// Verify an ed25519 signature and emit log output for each step.
+fn verify_packet_signature(
+    verifying_key: &VerifyingKey,
+    message: &[u8],
+    signature: &Ed25519Signature,
+) -> Result<(), String> {
+    println!("🔵 Verifying signature... (msg {} bytes)", message.len());
+    match verify_ed25519(verifying_key, message, signature) {
+        Ok(_) => {
+            println!("🟢 Signature valid");
+            Ok(())
+        }
+        Err(e) => {
+            println!("🔴 Signature verification failed: {:?}", e);
+            Err("Signature verification failed".into())
+        }
+    }
+}
+
 /// Validate an `AITcpPacket` by checking its sequence number and signature.
 ///
 /// The sequence number is expected to be stored in little endian format in
@@ -17,9 +36,13 @@ pub fn validate_packet(
     verifying_key: &VerifyingKey,
     expected_sequence: u64,
 ) -> Result<(), String> {
+    println!("🔵 Validating packet (expected seq {})", expected_sequence);
+
     // Verify sequence number length
     let seq_vec = packet.encrypted_sequence_id();
+    println!("🔵 Sequence field length: {}", seq_vec.len());
     if seq_vec.len() != 8 {
+        println!("🔴 Invalid sequence ID length: {}", seq_vec.len());
         return Err("Invalid sequence ID length".into());
     }
 
@@ -29,13 +52,23 @@ pub fn validate_packet(
         *dst = src;
     }
     let seq = u64::from_le_bytes(seq_bytes);
+    println!("🔵 Sequence number extracted: {}", seq);
     if seq != expected_sequence {
-        return Err(format!("Sequence ID mismatch: expected {}, got {}", expected_sequence, seq));
+        println!(
+            "🔴 Sequence ID mismatch: expected {}, got {}",
+            expected_sequence, seq
+        );
+        return Err(format!(
+            "Sequence ID mismatch: expected {}, got {}",
+            expected_sequence, seq
+        ));
     }
 
     // Prepare signature
     let sig_vec = packet.signature();
+    println!("🔵 Signature length: {}", sig_vec.len());
     if sig_vec.len() != 64 {
+        println!("🔴 Invalid signature length: {}", sig_vec.len());
         return Err("Invalid signature length".into());
     }
     let mut sig_bytes = [0u8; 64];
@@ -44,12 +77,18 @@ pub fn validate_packet(
     }
     let signature = Ed25519Signature::from_bytes(&sig_bytes);
 
-    // Verify signature
-    let message: Vec<u8> = packet.encrypted_payload().iter().collect();
+    // Verify payload
+    let payload_vec = packet.encrypted_payload();
+    println!("🔵 Payload length: {}", payload_vec.len());
+    if payload_vec.is_empty() {
+        println!("🔴 Empty payload not allowed");
+        return Err("Empty payload".into());
+    }
+    let message: Vec<u8> = payload_vec.iter().collect();
 
-    // Delegate to the shared helper for Ed25519 verification. Using the helper
-    // keeps the logic consistent across crates and allows future changes (such
-    // as domain separation) to be applied in one place.
-    verify_ed25519(verifying_key, &message, &signature)
-        .map_err(|_| "Signature verification failed".into())
+    // Delegate to helper
+    verify_packet_signature(verifying_key, &message, &signature)?;
+
+    println!("🟢 Packet validation succeeded");
+    Ok(())
 }

--- a/rust-core/tests/packet_validator_test.rs
+++ b/rust-core/tests/packet_validator_test.rs
@@ -3,9 +3,9 @@
 // ===========================
 
 use ed25519_dalek::{SigningKey, VerifyingKey};
-use kairo_core::keygen::ephemeral_key;
 use flatbuffers::FlatBufferBuilder;
 use kairo_core::ai_tcp_packet_generated::aitcp as fb;
+use kairo_core::keygen::ephemeral_key;
 use kairo_core::packet_validator::validate_packet;
 use kairo_core::signature::sign_ed25519;
 
@@ -18,6 +18,32 @@ fn build_packet(seq: u64, key: &SigningKey, payload: &[u8]) -> Vec<u8> {
     let payload_vec = builder.create_vector(payload);
     let sig = sign_ed25519(key, payload);
     let sig_vec = builder.create_vector(sig.to_bytes().as_ref());
+    let packet_offset = fb::AITcpPacket::create(
+        &mut builder,
+        &fb::AITcpPacketArgs {
+            version: 1,
+            ephemeral_key: Some(ephemeral_key_vec),
+            nonce: Some(nonce_vec),
+            encrypted_sequence_id: Some(seq_vec),
+            encrypted_payload: Some(payload_vec),
+            signature: Some(sig_vec),
+            header: None,
+            payload: None,
+            footer: None,
+        },
+    );
+    builder.finish(packet_offset, None);
+    builder.finished_data().to_vec()
+}
+
+/// Build a packet with a raw signature value.
+fn build_packet_with_sig(seq: u64, payload: &[u8], signature: &[u8]) -> Vec<u8> {
+    let mut builder = FlatBufferBuilder::new();
+    let ephemeral_key_vec = builder.create_vector(&[1u8; 32]);
+    let nonce_vec = builder.create_vector(&[0u8; 12]);
+    let seq_vec = builder.create_vector(&seq.to_le_bytes());
+    let payload_vec = builder.create_vector(payload);
+    let sig_vec = builder.create_vector(signature);
     let packet_offset = fb::AITcpPacket::create(
         &mut builder,
         &fb::AITcpPacketArgs {
@@ -51,7 +77,8 @@ fn validate_wrong_sequence() {
     let payload = b"hello";
     let _buf = build_packet(1, &key, payload);
     let packet = fb::root_as_aitcp_packet(&_buf).unwrap();
-    assert!(validate_packet(&packet, &VerifyingKey::from(&key), 2).is_err());
+    let err = validate_packet(&packet, &VerifyingKey::from(&key), 2).unwrap_err();
+    assert!(err.contains("Sequence ID mismatch"));
 }
 
 #[test]
@@ -60,30 +87,19 @@ fn validate_bad_signature() {
     let payload = b"hello";
     let _buf = build_packet(1, &key, payload);
 
-    // Tamper signature: build new buffer with zeroed signature
-    let mut builder = FlatBufferBuilder::new();
-    let ephemeral_key_vec = builder.create_vector(&[1u8; 32]);
-    let nonce_vec = builder.create_vector(&[0u8; 12]);
-    let seq_vec = builder.create_vector(&1u64.to_le_bytes());
-    let payload_vec = builder.create_vector(payload);
-    let sig_vec = builder.create_vector(&[0u8; 64]);
-    let packet_offset = fb::AITcpPacket::create(
-        &mut builder,
-        &fb::AITcpPacketArgs {
-            version: 1,
-            ephemeral_key: Some(ephemeral_key_vec),
-            nonce: Some(nonce_vec),
-            encrypted_sequence_id: Some(seq_vec),
-            encrypted_payload: Some(payload_vec),
-            signature: Some(sig_vec),
-            header: None,
-            payload: None,
-            footer: None,
-        },
-    );
-    builder.finish(packet_offset, None);
-    let tampered_buf = builder.finished_data();
-    let packet = fb::root_as_aitcp_packet(tampered_buf).unwrap();
+    // Tamper signature using zeroed bytes
+    let tampered_buf = build_packet_with_sig(1, payload, &[0u8; 64]);
+    let packet = fb::root_as_aitcp_packet(&tampered_buf).unwrap();
+    let err = validate_packet(&packet, &VerifyingKey::from(&key), 1).unwrap_err();
+    assert!(err.contains("Signature verification failed"));
+}
 
-    assert!(validate_packet(&packet, &VerifyingKey::from(&key), 1).is_err());
+#[test]
+fn validate_missing_signature() {
+    let key = SigningKey::from_bytes(&ephemeral_key());
+    let payload = b"hello";
+    let buf = build_packet_with_sig(1, payload, &[]);
+    let packet = fb::root_as_aitcp_packet(&buf).unwrap();
+    let err = validate_packet(&packet, &VerifyingKey::from(&key), 1).unwrap_err();
+    assert_eq!(err, "Invalid signature length");
 }


### PR DESCRIPTION
## Summary
- add helper `verify_packet_signature` with detailed println logs
- expand `validate_packet` to log failure reasons and validate payload
- enhance `packet_validator_test.rs` with error checks and missing field case

## Testing
- `cargo test -p kairo_core --offline` *(fails: no matching package named `bytes`)*

------
https://chatgpt.com/codex/tasks/task_e_68852e9e26fc8333af22e02271aa8438