### PR TITLE
Add mesh UDP sender utility and python module support

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+src_root = Path(__file__).resolve().parent
+if str(src_root) not in sys.path:
+    sys.path.insert(0, str(src_root))
+
+helper_path = src_root / 'kairo_lib' / 'py'
+if str(helper_path) not in sys.path:
+    sys.path.insert(0, str(helper_path))
+
+from .errors import *
+from .log_recorder import *
+
+__all__ = []

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -31,6 +31,10 @@ name = "send_message"
 path = "send_message.rs"
 
 [[bin]]
+name = "mesh_udp_sender"
+path = "mesh_udp_sender.rs"
+
+[[bin]]
 name = "receive_signed"
 path = "receive_signed.rs"
 

--- a/src/agent/mesh_udp_sender.rs
+++ b/src/agent/mesh_udp_sender.rs
@@ -1,0 +1,28 @@
+// UDP経由Meshノードへパケット送信（mesh_nodeとペア）
+use std::net::UdpSocket;
+use serde::Serialize;
+use std::env;
+
+#[derive(Serialize)]
+struct MeshPacket {
+    from: String,
+    to: String,
+    payload: String,
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 4 {
+        eprintln!("Usage: {} <from> <to> <payload>", args[0]);
+        return;
+    }
+    let packet = MeshPacket {
+        from: args[1].clone(),
+        to: args[2].clone(),
+        payload: args[3].clone(),
+    };
+    let json = serde_json::to_vec(&packet).unwrap();
+    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    socket.send_to(&json, "127.0.0.1:5050").unwrap();
+    println!("✅ Sent packet to mesh_node.");
+}

--- a/src/errors.py
+++ b/src/errors.py
@@ -1,0 +1,1 @@
+from kairo_lib.py.errors import *

--- a/src/kairo_lib
+++ b/src/kairo_lib
@@ -1,0 +1,1 @@
+kairo-lib

--- a/src/log_recorder.py
+++ b/src/log_recorder.py
@@ -1,0 +1,1 @@
+from kairo_lib.py.log_recorder import *


### PR DESCRIPTION
## Summary
- add `mesh_udp_sender` Rust binary for UDP packets
- register the binary in agent `Cargo.toml`
- expose Python helpers under `src` to satisfy unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853359cd648333bed3d613b5346ab0