### PR TITLE
Add log option to mesh_node CLI

### DIFF
--- a/src/mesh-node/Cargo.toml
+++ b/src/mesh-node/Cargo.toml
@@ -8,6 +8,7 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 eyre = "0.6"
+clap = { version = "4", features = ["derive"] }
 
 [[bin]]
 name = "mesh_node"

--- a/src/mesh-node/src/main.rs
+++ b/src/mesh-node/src/main.rs
@@ -1,3 +1,23 @@
+use clap::Parser;
+use std::fs::OpenOptions;
+use std::io::Write;
+
+#[derive(Parser)]
+struct Args {
+    /// Log file path
+    #[arg(long)]
+    log: Option<String>,
+}
+
 fn main() {
+    let args = Args::parse();
+    let mut logfile = args
+        .log
+        .as_ref()
+        .and_then(|p| OpenOptions::new().create(true).append(true).open(p).ok());
+
     println!("Mesh node started.");
+    if let Some(file) = logfile.as_mut() {
+        let _ = writeln!(file, "Mesh node started.");
+    }
 }


### PR DESCRIPTION
## Summary
- extend mesh_node CLI to accept optional `--log` argument
- log startup message to the specified file
- include `clap` dependency for argument parsing

## Testing
- `cargo test --no-run` *(fails: failed to download index)*

------
https://chatgpt.com/codex/tasks/task_e_6885544ceb2c8333873f8777a59bd0e2