### PR TITLE
Add source_public_key field to packet

### DIFF
--- a/src/kairo-lib/packet.rs
+++ b/src/kairo-lib/packet.rs
@@ -12,5 +12,6 @@ pub struct AiTcpPacket {
     pub timestamp_utc: i64, // UNIX epoch seconds (UTC)
     pub payload_type: String, // e.g., "text/plain", "application/json"
     pub payload: String,
+    pub source_public_key: String,
     pub signature: String, // Hex-encoded signature of (sequence + timestamp + payload)
 }


### PR DESCRIPTION
## Summary
- extend `AiTcpPacket` with a `source_public_key` field

## Testing
- `cargo check` *(fails: failed to download from crates.io because internet access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68855d46a0508333b963285a041a028a