### PR TITLE
Add functional core to KAIROBOT

### DIFF
--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -16,6 +16,7 @@ uuid = { version = "1.7", features = ["v4"] }
 warp = "0.3"
 thiserror = "1.0"
 bytes = "1.6"
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 criterion = "0.7.0"

--- a/rust-core/src/bot/core/mod.rs
+++ b/rust-core/src/bot/core/mod.rs
@@ -1,3 +1,102 @@
 //! src/bot/core/mod.rs
 // The Core layer: Manages fundamental principles, safety, and failsafes.
 
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::time::{sleep, Duration};
+use uuid::Uuid;
+
+/// Status of a [`Task`] within the queue.
+#[derive(Clone, Debug)]
+pub enum TaskStatus {
+    Pending,
+    InProgress,
+    Completed,
+    Failed,
+}
+
+/// A unit of work for the `KAIROBOT`.
+#[derive(Clone, Debug)]
+pub struct Task {
+    pub id: String,
+    pub name: String,
+    pub command: String,
+    pub status: TaskStatus,
+}
+
+/// A simple in-memory queue for [`Task`]s.
+#[derive(Default)]
+pub struct TaskQueue {
+    pub tasks: Vec<Task>,
+}
+
+impl TaskQueue {
+    /// Create a new empty queue.
+    pub fn new() -> Self {
+        Self { tasks: Vec::new() }
+    }
+
+    /// Add a task to the queue and return its generated ID.
+    pub fn push(&mut self, name: impl Into<String>, command: impl Into<String>) -> String {
+        let id = Uuid::new_v4().to_string();
+        self.tasks.push(Task {
+            id: id.clone(),
+            name: name.into(),
+            command: command.into(),
+            status: TaskStatus::Pending,
+        });
+        id
+    }
+
+    /// Gets the next pending task and sets its status to [`TaskStatus::InProgress`].
+    pub fn get_next_task(&mut self) -> Option<Task> {
+        if let Some(task) = self
+            .tasks
+            .iter_mut()
+            .find(|t| matches!(t.status, TaskStatus::Pending))
+        {
+            task.status = TaskStatus::InProgress;
+            return Some(task.clone());
+        }
+        None
+    }
+
+    /// Updates the status of a task by its ID.
+    pub fn update_task_status(&mut self, task_id: &str, status: TaskStatus) {
+        if let Some(task) = self.tasks.iter_mut().find(|t| t.id == task_id) {
+            task.status = status;
+        }
+    }
+}
+
+/// The main loop of the KAIROBOT.
+pub async fn main_loop(queue: Arc<Mutex<TaskQueue>>) {
+    println!("KAIROBOT Core: Main loop started.");
+    loop {
+        let task_to_run;
+        {
+            let mut q = queue.lock().await;
+            task_to_run = q.get_next_task();
+        }
+
+        if let Some(task) = task_to_run {
+            println!("Executing task: {} ({})", task.name, task.id);
+            // TODO: Dispatch to the plugin layer
+            let success = crate::bot::plugin::shell::execute(&task.command).await;
+
+            let final_status = if success {
+                TaskStatus::Completed
+            } else {
+                TaskStatus::Failed
+            };
+            {
+                let mut q = queue.lock().await;
+                q.update_task_status(&task.id, final_status);
+            }
+            println!("Task {} finished.", task.id);
+        } else {
+            sleep(Duration::from_secs(5)).await;
+        }
+    }
+}
+

--- a/rust-core/src/bot/plugin/mod.rs
+++ b/rust-core/src/bot/plugin/mod.rs
@@ -1,3 +1,5 @@
 //! src/bot/plugin/mod.rs
 // The Plugin layer: Contains specific, task-oriented logic (e.g., 'run_build', 'deploy_docs').
 
+pub mod shell;
+

--- a/rust-core/src/bot/plugin/shell.rs
+++ b/rust-core/src/bot/plugin/shell.rs
@@ -1,0 +1,27 @@
+//! src/bot/plugin/shell.rs
+// A simple plugin to execute shell commands.
+
+use tokio::process::Command;
+
+/// Execute a shell command asynchronously.
+pub async fn execute(command: &str) -> bool {
+    println!("Plugin(Shell): Running '{}'", command);
+
+    let mut parts = command.split_whitespace();
+    let program = parts.next().unwrap_or_default();
+    let args: Vec<&str> = parts.collect();
+
+    let Ok(mut child) = Command::new(program).args(&args).spawn() else {
+        eprintln!("Plugin(Shell): Failed to spawn command.");
+        return false;
+    };
+
+    match child.wait().await {
+        Ok(status) => status.success(),
+        Err(_) => {
+            eprintln!("Plugin(Shell): Command failed to run.");
+            false
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- flesh out KAIROBOT core with task queue and async loop
- implement shell plugin for running commands
- wire shell plugin into plugin module
- add `tokio` dependency

## Testing
- `cargo test --quiet` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6889502d43dc8333a17db18e43da095f