### PR TITLE
Implement add_task endpoint

### DIFF
--- a/src/kairo-daemon/api/controller.rs
+++ b/src/kairo-daemon/api/controller.rs
@@ -1,0 +1,24 @@
+use axum::{extract::State, Json, http::StatusCode};
+use serde::Deserialize;
+use std::sync::{Arc, Mutex};
+
+use crate::task_queue::{TaskQueue, Task};
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct AddTaskRequest {
+    pub id: String,
+    pub name: String,
+    pub command: String,
+}
+
+pub async fn add_task(
+    State(queue): State<Arc<Mutex<TaskQueue>>>,
+    Json(req): Json<AddTaskRequest>,
+) -> (StatusCode, &'static str) {
+    {
+        let mut q = queue.lock().expect("TaskQueue lock");
+        q.add_task(Task { id: req.id.clone(), name: req.name.clone(), command: req.command.clone() });
+    }
+    println!("[ADD_TASK] id={} name={} command={}", req.id, req.name, req.command);
+    (StatusCode::OK, "ok")
+}

--- a/src/kairo-daemon/main.rs
+++ b/src/kairo-daemon/main.rs
@@ -1,7 +1,12 @@
 mod handler;
+mod task_queue;
+mod api {
+    pub mod controller;
+}
 
 use std::net::SocketAddr;
 use std::fs::File;
+use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
 
 use axum::{
@@ -11,6 +16,8 @@ use axum::{
 
 use simplelog::{CombinedLogger, TermLogger, WriteLogger, Config as LogConfig, TerminalMode, ColorChoice, LevelFilter};
 use handler::{handle_send, handle_gpt};
+use task_queue::TaskQueue;
+use api::controller::add_task;
 
 // エントリポイント
 #[tokio::main]
@@ -26,11 +33,16 @@ async fn main() {
     ])
     .unwrap();
 
+    // ✅ TaskQueue 初期化
+    let queue = Arc::new(Mutex::new(TaskQueue::new()));
+
     // ✅ Router 設定
     let app = Router::new()
         .route("/", get(root))
         .route("/send", post(handle_send))
-        .route("/gpt", post(handle_gpt));
+        .route("/gpt", post(handle_gpt))
+        .route("/add_task", post(add_task))
+        .with_state(queue.clone());
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
     println!("Listening on {}", addr);
@@ -44,3 +56,4 @@ async fn main() {
 async fn root() -> &'static str {
     "KAIRO Daemon Online"
 }
+

--- a/src/kairo-daemon/task_queue.rs
+++ b/src/kairo-daemon/task_queue.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Task {
+    pub id: String,
+    pub name: String,
+    pub command: String,
+}
+
+#[derive(Default)]
+pub struct TaskQueue {
+    tasks: Vec<Task>,
+}
+
+impl TaskQueue {
+    pub fn new() -> Self {
+        Self { tasks: Vec::new() }
+    }
+
+    pub fn add_task(&mut self, task: Task) {
+        self.tasks.push(task);
+    }
+}


### PR DESCRIPTION
## Summary
- implement a simple `TaskQueue` and `Task` structure
- add `/add_task` POST endpoint under `api::controller`
- wire the new route and queue into `kairo-daemon` server

## Testing
- `cargo check --offline` *(fails: no matching package named `bytes` found)*

------
https://chatgpt.com/codex/tasks/task_e_688950e6d0bc8333928ae87b3034dc6a