### PR TITLE
Implement bot API receiver and main

### DIFF
--- a/rust-core/src/bot/api/mod.rs
+++ b/rust-core/src/bot/api/mod.rs
@@ -1,3 +1,5 @@
 //! src/bot/api/mod.rs
 // The API layer: Provides interfaces to interact with external tools (Git, Docker, etc.).
 
+
+pub mod receiver;

--- a/rust-core/src/bot/api/receiver.rs
+++ b/rust-core/src/bot/api/receiver.rs
@@ -1,0 +1,22 @@
+//! src/bot/api/receiver.rs
+// The API endpoint for receiving new tasks.
+
+use crate::bot::core::{Task, TaskQueue};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use warp::Filter;
+
+pub fn create_task_route(queue: Arc<Mutex<TaskQueue>>) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::post()
+        .and(warp::path("add_task"))
+        .and(warp::body::json())
+        .and(warp::any().map(move || Arc::clone(&queue)))
+        .and_then(add_task_handler)
+}
+
+async fn add_task_handler(task: Task, queue: Arc<Mutex<TaskQueue>>) -> Result<impl warp::Reply, warp::Rejection> {
+    println!("API: Received new task -> {}", task.name);
+    let mut q = queue.lock().await;
+    q.add_task(task);
+    Ok(warp::reply::json(&"Task added successfully"))
+}

--- a/src/bot/main.rs
+++ b/src/bot/main.rs
@@ -1,0 +1,30 @@
+//! src/bot/main.rs
+// The main entry point for the KAIROBOT.
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use crate::bot::core::{TaskQueue, main_loop};
+use crate::bot::api::receiver;
+
+#[tokio::main]
+async fn main() {
+    println!("KAIROBOT: Starting bootstrap process...");
+
+    let task_queue = Arc::new(Mutex::new(TaskQueue::new()));
+
+    // Start the API server in a separate task
+    let api_task_queue = Arc::clone(&task_queue);
+    let api_server = tokio::spawn(async move {
+        let routes = receiver::create_task_route(api_task_queue);
+        println!("KAIROBOT API: Listening on http://127.0.0.1:4040");
+        warp::serve(routes).run(([127, 0, 0, 1], 4040)).await;
+    });
+
+    // Start the core processing loop
+    let core_loop = tokio::spawn(async move {
+        main_loop(task_queue).await;
+    });
+
+    // Keep the bot alive
+    let _ = tokio::try_join!(api_server, core_loop);
+}


### PR DESCRIPTION
## Summary
- add a warp route for receiving tasks
- hook receiver into API module
- add initial bot entry point

## Testing
- `cargo check -p kairo_core` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_688951a84f3c8333a10ea4086e9a6677