### PR TITLE
Implement status tracking and API route

### DIFF
--- a/rust-core/src/bot/api/mod.rs
+++ b/rust-core/src/bot/api/mod.rs
@@ -3,3 +3,4 @@
 
 
 pub mod receiver;
+pub mod status;

--- a/rust-core/src/bot/api/status.rs
+++ b/rust-core/src/bot/api/status.rs
@@ -1,0 +1,20 @@
+//! src/bot/api/status.rs
+// The API endpoint for querying task statuses.
+
+use crate::bot::core::{Task, TaskQueue};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use warp::Filter;
+
+pub fn create_status_route(queue: Arc<Mutex<TaskQueue>>) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::get()
+        .and(warp::path("status"))
+        .and(warp::any().map(move || Arc::clone(&queue)))
+        .and_then(status_handler)
+}
+
+async fn status_handler(queue: Arc<Mutex<TaskQueue>>) -> Result<impl warp::Reply, warp::Rejection> {
+    println!("API: Status request received.");
+    let q = queue.lock().await;
+    Ok(warp::reply::json(&q.tasks))
+}

--- a/rust-core/src/bot/core/mod.rs
+++ b/rust-core/src/bot/core/mod.rs
@@ -64,6 +64,7 @@ impl TaskQueue {
     /// Updates the status of a task by its ID.
     pub fn update_task_status(&mut self, task_id: &str, status: TaskStatus) {
         if let Some(task) = self.tasks.iter_mut().find(|t| t.id == task_id) {
+            println!("Core: Updating status for task '{}' to {:?}", task_id, status);
             task.status = status;
         }
     }
@@ -71,7 +72,7 @@ impl TaskQueue {
 
 /// The main loop of the KAIROBOT.
 pub async fn main_loop(queue: Arc<Mutex<TaskQueue>>) {
-    println!("KAIROBOT Core: Main loop started.");
+    println!("KAIROBOT Core: Main loop started. Monitoring task queue...");
     loop {
         let task_to_run;
         {
@@ -80,7 +81,7 @@ pub async fn main_loop(queue: Arc<Mutex<TaskQueue>>) {
         }
 
         if let Some(task) = task_to_run {
-            println!("Executing task: {} ({})", task.name, task.id);
+            println!("Core: Executing task '{}' ({})", task.name, task.id);
             // TODO: Dispatch to the plugin layer
             let success = crate::bot::plugin::shell::execute(&task.command).await;
 
@@ -93,9 +94,8 @@ pub async fn main_loop(queue: Arc<Mutex<TaskQueue>>) {
                 let mut q = queue.lock().await;
                 q.update_task_status(&task.id, final_status);
             }
-            println!("Task {} finished.", task.id);
         } else {
-            sleep(Duration::from_secs(5)).await;
+            sleep(Duration::from_secs(2)).await;
         }
     }
 }

--- a/src/bot/main.rs
+++ b/src/bot/main.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use crate::bot::core::{TaskQueue, main_loop};
-use crate::bot::api::receiver;
+use crate::bot::api::{receiver, status};
 
 #[tokio::main]
 async fn main() {
@@ -15,7 +15,9 @@ async fn main() {
     // Start the API server in a separate task
     let api_task_queue = Arc::clone(&task_queue);
     let api_server = tokio::spawn(async move {
-        let routes = receiver::create_task_route(api_task_queue);
+        let add_task_route = receiver::create_task_route(Arc::clone(&api_task_queue));
+        let status_route = status::create_status_route(Arc::clone(&api_task_queue));
+        let routes = add_task_route.or(status_route);
         println!("KAIROBOT API: Listening on http://127.0.0.1:4040");
         warp::serve(routes).run(([127, 0, 0, 1], 4040)).await;
     });


### PR DESCRIPTION
## Summary
- improve task queue status updates with log output
- expose new `/status` API endpoint for checking tasks
- register `status` API module
- integrate status route in bot startup

## Testing
- `cargo check -p kairo_core` *(fails: unable to access crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68895f7e1fa083338012cc0c78de180f