### PR TITLE
Implement bot status API

### DIFF
--- a/src/bot/api/mod.rs
+++ b/src/bot/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod status;

--- a/src/bot/api/status.rs
+++ b/src/bot/api/status.rs
@@ -1,0 +1,20 @@
+//! src/bot/api/status.rs
+// The API endpoint for querying task statuses.
+
+use crate::bot::core::{Task, TaskQueue};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use warp::Filter;
+
+pub fn create_status_route(queue: Arc<Mutex<TaskQueue>>) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::get()
+        .and(warp::path("status"))
+        .and(warp::any().map(move || Arc::clone(&queue)))
+        .and_then(status_handler)
+}
+
+async fn status_handler(queue: Arc<Mutex<TaskQueue>>) -> Result<impl warp::Reply, warp::Rejection> {
+    println!("API: Status request received.");
+    let q = queue.lock().await;
+    Ok(warp::reply::json(&q.tasks))
+}


### PR DESCRIPTION
## Summary
- add status API endpoint for bot
- expose the new status module

## Testing
- `cargo test --workspace --quiet` *(fails: couldn't access crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68896098a86c83338061db61f24d2967