### PR TITLE
Add task queue persistence

### DIFF
--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -24,6 +24,7 @@ warp = "0.3"
 thiserror = "1.0"
 bytes = "1.6"
 tokio = { version = "1", features = ["full"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 criterion = "0.7.0"

--- a/rust-core/src/bot/api/receiver.rs
+++ b/rust-core/src/bot/api/receiver.rs
@@ -18,5 +18,8 @@ async fn add_task_handler(task: Task, queue: Arc<Mutex<TaskQueue>>) -> Result<im
     println!("API: Received new task -> {}", task.name);
     let mut q = queue.lock().await;
     q.add_task(task);
+    if let Err(e) = q.save() {
+        eprintln!("API: Error saving task queue: {}", e);
+    }
     Ok(warp::reply::json(&"Task added successfully"))
 }

--- a/rust-core/src/bot/core/mod.rs
+++ b/rust-core/src/bot/core/mod.rs
@@ -2,6 +2,10 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 use uuid::Uuid;
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, BufWriter};
+
+const QUEUE_FILE: &str = "task_queue.json";
 
 /// Status of a [`Task`] within the queue.
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -22,7 +26,7 @@ pub struct Task {
 }
 
 /// A simple in-memory queue for [`Task`]s.
-#[derive(Default)]
+#[derive(Default, serde::Deserialize, serde::Serialize)]
 pub struct TaskQueue {
     pub tasks: Vec<Task>,
 }
@@ -59,6 +63,32 @@ impl TaskQueue {
             println!("Core: Updating status for task '{}' to {:?}", task_id, status);
             task.status = status;
         }
+    }
+
+    /// Load the task queue from a file
+    pub fn load() -> Self {
+        if let Ok(file) = File::open(QUEUE_FILE) {
+            let reader = BufReader::new(file);
+            if let Ok(queue) = serde_json::from_reader(reader) {
+                println!("Core: Task queue loaded from {}", QUEUE_FILE);
+                return queue;
+            }
+        }
+        println!("Core: No existing task queue found. Creating a new one.");
+        Self::new()
+    }
+
+    /// Save the entire task queue to a file
+    pub fn save(&self) -> Result<(), std::io::Error> {
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(QUEUE_FILE)?;
+        let writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(writer, &self.tasks)?;
+        println!("Core: Task queue saved to {}", QUEUE_FILE);
+        Ok(())
     }
 }
 

--- a/src/bot/main.rs
+++ b/src/bot/main.rs
@@ -10,7 +10,7 @@ use crate::bot::api::{receiver, status};
 async fn main() {
     println!("KAIROBOT: Starting bootstrap process...");
 
-    let task_queue = Arc::new(Mutex::new(TaskQueue::new()));
+    let task_queue = Arc::new(Mutex::new(TaskQueue::load()));
 
     // Start the API server in a separate task
     let api_task_queue = Arc::clone(&task_queue);


### PR DESCRIPTION
## Summary
- implement loading/saving the task queue
- log errors when saving fails
- initialise bot with stored queue
- add serde_json dependency

## Testing
- `cargo check` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_6889654b14488333b833a8e0ec801b2b