### PR TITLE
Add simple web UI for bot task submission

### DIFF
--- a/src/bot/main.rs
+++ b/src/bot/main.rs
@@ -17,7 +17,8 @@ async fn main() {
     let api_server = tokio::spawn(async move {
         let add_task_route = receiver::create_task_route(Arc::clone(&api_task_queue));
         let status_route = status::create_status_route(Arc::clone(&api_task_queue));
-        let routes = add_task_route.or(status_route);
+        let ui_route = warp::path("ui").and(warp::fs::dir("./src/bot/ui/"));
+        let routes = add_task_route.or(status_route).or(ui_route);
         println!("KAIROBOT API: Listening on http://127.0.0.1:4040");
         warp::serve(routes).run(([127, 0, 0, 1], 4040)).await;
     });

--- a/src/bot/ui/index.html
+++ b/src/bot/ui/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head><title>KAIROBOT Task Sender</title><style>body{font-family:sans-serif;background:#282c34;color:white;padding:2em;} input{width:300px;margin-bottom:1em;}</style></head>
+<body>
+  <h1>KAIROBOT Task Sender</h1>
+  <label>ID: <input id="task_id" value="task-003" /></label><br />
+  <label>Name: <input id="task_name" value="New Task from UI" /></label><br />
+  <label>Command: <input id="task_command" value="echo Hello from Web UI" /></label><br />
+  <button onclick="sendTask()">Send Task</button>
+
+  <script>
+    function sendTask() {
+      const data = {
+        id: document.getElementById("task_id").value,
+        name: document.getElementById("task_name").value,
+        command: document.getElementById("task_command").value,
+        status: "Pending"
+      };
+
+      fetch("http://localhost:4040/add_task", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data)
+      }).then(resp => {
+        if (resp.ok) alert("Task sent!");
+        else alert("Error: " + resp.status);
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `src/bot/ui/index.html` with a basic HTML form
- serve the UI through `/ui` in `src/bot/main.rs`

## Testing
- `cargo fmt -- src/bot/main.rs`
- `cargo check` *(failed: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_688966732dfc8333abb5d33fb6cc75c6