### PR TITLE
Implement persistent task queue

### DIFF
--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -24,6 +24,7 @@ warp = "0.3"
 thiserror = "1.0"
 bytes = "1.6"
 tokio = { version = "1", features = ["full"] }
+serde_json = "1"
 
 [dev-dependencies]
 criterion = "0.7.0"

--- a/rust-core/src/bot/api/receiver.rs
+++ b/rust-core/src/bot/api/receiver.rs
@@ -18,5 +18,8 @@ async fn add_task_handler(task: Task, queue: Arc<Mutex<TaskQueue>>) -> Result<im
     println!("API: Received new task -> {}", task.name);
     let mut q = queue.lock().await;
     q.add_task(task);
+    if let Err(e) = q.save() {
+        eprintln!("API: Error saving task queue: {}", e);
+    }
     Ok(warp::reply::json(&"Task added successfully"))
 }

--- a/rust-core/src/bot/core/mod.rs
+++ b/rust-core/src/bot/core/mod.rs
@@ -1,4 +1,8 @@
 use std::sync::Arc;
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, BufWriter};
+
+const QUEUE_FILE: &str = "task_queue.json";
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 use uuid::Uuid;
@@ -31,6 +35,32 @@ impl TaskQueue {
     /// Create a new empty queue.
     pub fn new() -> Self {
         Self { tasks: Vec::new() }
+    }
+
+    /// Load the task queue from a file
+    pub fn load() -> Self {
+        if let Ok(file) = File::open(QUEUE_FILE) {
+            let reader = BufReader::new(file);
+            if let Ok(queue) = serde_json::from_reader(reader) {
+                println!("Core: Task queue loaded from {}", QUEUE_FILE);
+                return queue;
+            }
+        }
+        println!("Core: No existing task queue found. Creating a new one.");
+        Self::new()
+    }
+
+    /// Save the entire task queue to a file
+    pub fn save(&self) -> Result<(), std::io::Error> {
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(QUEUE_FILE)?;
+        let writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(writer, &self.tasks)?;
+        println!("Core: Task queue saved to {}", QUEUE_FILE);
+        Ok(())
     }
 
     /// Add a task to the queue and return its generated ID.

--- a/rust-core/src/main.rs
+++ b/rust-core/src/main.rs
@@ -6,7 +6,7 @@ use warp::Filter;
 
 #[tokio::main]
 async fn main() {
-    let queue = Arc::new(Mutex::new(TaskQueue::new()));
+    let queue = Arc::new(Mutex::new(TaskQueue::load()));
 
     // APIサーバーの起動
     let api_routes = create_task_route(queue.clone());

--- a/src/bot/main.rs
+++ b/src/bot/main.rs
@@ -10,7 +10,7 @@ use crate::bot::api::{receiver, status};
 async fn main() {
     println!("KAIROBOT: Starting bootstrap process...");
 
-    let task_queue = Arc::new(Mutex::new(TaskQueue::new()));
+    let task_queue = Arc::new(Mutex::new(TaskQueue::load()));
 
     // Start the API server in a separate task
     let api_task_queue = Arc::clone(&task_queue);


### PR DESCRIPTION
## Summary
- add JSON persistence to bot task queue and save/load operations
- persist queue to disk when adding tasks via API
- load existing queue at startup
- include serde_json dependency

## Testing
- `cargo test --workspace --no-run` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_688965bce1e8833387dabcef9bcece57