### PR TITLE
UI packet sender feature

### DIFF
--- a/src/bot/main.rs
+++ b/src/bot/main.rs
@@ -7,6 +7,49 @@ use crate::bot::core::{TaskQueue, main_loop};
 use crate::bot::api::{receiver, status};
 use warp::Filter;
 
+use kairo_lib::config::{self, AgentConfig};
+use kairo_lib::packet::AiTcpPacket;
+use ed25519_dalek::{Signer, SigningKey};
+use chrono::Utc;
+
+#[derive(Debug, serde::Deserialize)]
+struct UiSendRequest {
+    to_p_address: String,
+    payload: String,
+}
+
+async fn handle_ui_send(req: UiSendRequest) -> Result<impl warp::Reply, warp::Rejection> {
+    let cli_config = match config::load_config_from_dir("./users/CLI") {
+        Some(c) => c,
+        None => return Ok(warp::reply::with_status(warp::reply::json(&"CLI agent config not found"), warp::http::StatusCode::INTERNAL_SERVER_ERROR))
+    };
+
+    let secret_key_bytes = hex::decode(&cli_config.secret_key).unwrap();
+    let signing_key = SigningKey::from_bytes(&secret_key_bytes);
+
+    let message_to_sign = req.payload.as_bytes();
+    let signature = signing_key.sign(message_to_sign);
+
+    let packet = AiTcpPacket {
+        version: 1,
+        source_p_address: cli_config.p_address,
+        destination_p_address: req.to_p_address,
+        sequence: 0,
+        timestamp_utc: Utc::now().timestamp(),
+        payload_type: "text/plain".to_string(),
+        payload: req.payload,
+        signature: hex::encode(signature.to_bytes()),
+    };
+
+    let client = reqwest::Client::new();
+    let res = client.post("http://localhost:3030/send").json(&packet).send().await;
+
+    match res {
+        Ok(response) => Ok(warp::reply::json(&response.status().as_u16())),
+        Err(_) => Ok(warp::reply::json(&"Failed to forward packet to daemon"))
+    }
+}
+
 #[tokio::main]
 async fn main() {
     println!("KAIROBOT: Starting bootstrap process...");
@@ -20,7 +63,8 @@ async fn main() {
         let status_route = status::create_status_route(Arc::clone(&api_task_queue));
         let health_check_route = warp::path::end().map(|| warp::reply::json(&"KAIROBOT is alive"));
         let ui_route = warp::path("ui").and(warp::fs::dir("./vov/kairobot_ui/"));
-        let routes = add_task_route.or(status_route).or(ui_route).or(health_check_route);
+        let send_signed_route = warp::post().and(warp::path("send_signed")).and(warp::body::json()).and_then(handle_ui_send);
+        let routes = add_task_route.or(status_route).or(ui_route).or(health_check_route).or(send_signed_route);
         println!("KAIROBOT API: Listening on http://127.0.0.1:4040");
         warp::serve(routes).run(([127, 0, 0, 1], 4040)).await;
     });

--- a/vov/kairobot_ui/index.html
+++ b/vov/kairobot_ui/index.html
@@ -1,30 +1,37 @@
 <!DOCTYPE html>
 <html>
-<head><title>KAIROBOT Task Sender</title><style>body{font-family:sans-serif;background:#282c34;color:white;padding:2em;} input{width:300px;margin-bottom:1em;}</style></head>
+<head><title>KAIRO AI-TCP Interface</title><style>body{font-family:sans-serif;background:#282c34;color:white;padding:2em;} input, textarea{width:500px;margin-bottom:1em;background:#333;color:white;border:1px solid #555;padding:0.5em;}</style></head>
 <body>
-  <h1>KAIROBOT Task Sender</h1>
-  <label>ID: <input id="task_id" value="task-003" /></label><br />
-  <label>Name: <input id="task_name" value="New Task from UI" /></label><br />
-  <label>Command: <input id="task_command" value="echo Hello from Web UI" /></label><br />
-  <button onclick="sendTask()">Send Task</button>
+  <h1>KAIRO AI-TCP Direct Communication</h1>
+  <p>This UI acts on behalf of the agent defined in <strong>./users/CLI/agent_config.json</strong></p>
+  <hr>
+  <label>To P-Address: <input id="to_p_address" value="p-address-of-agent2" /></label><br />
+  <label>Payload (Message): <textarea id="payload" rows="4">Hello from another AI via UI</textarea></label><br />
+  <button onclick="sendPacket()">Send Signed Packet</button>
+  <h2>Response Log</h2>
+  <pre id="response_log"></pre>
 
   <script>
-    function sendTask() {
+    async function sendPacket() {
       const data = {
-        id: document.getElementById("task_id").value,
-        name: document.getElementById("task_name").value,
-        command: document.getElementById("task_command").value,
-        status: "Pending"
+        to_p_address: document.getElementById("to_p_address").value,
+        payload: document.getElementById("payload").value
       };
 
-      fetch("http://localhost:4040/add_task", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data)
-      }).then(resp => {
-        if (resp.ok) alert("Task sent!");
-        else alert("Error: " + resp.status);
-      });
+      const log = document.getElementById("response_log");
+      log.textContent = "Sending signed packet...";
+
+      try {
+        const response = await fetch("http://localhost:4040/send_signed", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(data)
+        });
+        const result = await response.json();
+        log.textContent = `Server Response:\n${JSON.stringify(result, null, 2)}`;
+      } catch (e) {
+        log.textContent = `Error: ${e.message}`;
+      }
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add a simple HTML UI to send signed packets from the CLI agent
- implement `handle_ui_send` route in bot
- expose `/send_signed` endpoint in bot server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'toml')*
- `cargo test --workspace --quiet` *(fails to fetch crates: failed to download from index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_688a38d68760833392baf5c98315ac77