### PR TITLE
Fix bot startup logic

### DIFF
--- a/src/bot/main.rs
+++ b/src/bot/main.rs
@@ -1,33 +1,37 @@
 //! src/bot/main.rs
-// The main entry point for the KAIROBOT.
+// The main entry point for the KAIROBOT, with corrected startup logic.
 
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use crate::bot::core::{TaskQueue, main_loop};
+// Corrected path to the bot's core logic in the 'kairo_core' crate.
+use kairo_core::bot::core::{TaskQueue, main_loop};
 use crate::bot::api::{receiver, status};
+use warp::Filter;
 
 #[tokio::main]
 async fn main() {
-    // Force logger initialization to ensure visibility
-    simple_logger::init_with_level(log::Level::Info).expect("Failed to initialize logger");
+    // Initialize logger to ensure visibility of all subsequent logs.
+    simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Info).init().expect("Failed to initialize logger");
 
-    println!("KAIROBOT: Starting bootstrap process...");
+    log::info!("KAIROBOT: Starting bootstrap process...");
 
+    // Load the persistent task queue.
     let task_queue = Arc::new(Mutex::new(TaskQueue::load()));
 
-    // Start the core processing loop as a background task
+    // --- Start Core Logic in the Background ---
     let core_task_queue = Arc::clone(&task_queue);
     tokio::spawn(async move {
         main_loop(core_task_queue).await;
     });
 
-    // Define API routes
+    // --- Start API Server in the Foreground ---
     let add_task_route = receiver::create_task_route(Arc::clone(&task_queue));
     let status_route = status::create_status_route(Arc::clone(&task_queue));
-    let routes = add_task_route.or(status_route);
+    let health_check_route = warp::path::end().map(|| warp::reply::json(&"KAIROBOT is alive"));
+    let routes = add_task_route.or(status_route).or(health_check_route);
 
-    println!("KAIROBOT API: Listening on http://127.0.0.1:4040");
+    log::info!("KAIROBOT API: Listening on http://127.0.0.1:4040");
 
-    // Start the API server in the foreground, keeping the main process alive
+    // Run the server in the foreground. This keeps the main process alive.
     warp::serve(routes).run(([127, 0, 0, 1], 4040)).await;
 }


### PR DESCRIPTION
## Summary
- update `src/bot/main.rs` to use the finalized API and core paths
- add a health-check route and improved logging

## Testing
- `cargo test --all --locked` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_688aa3f8d7c88333bbb7e8660c417475