### PR TITLE
Externalize WAU thresholds and apply hysteresis

### DIFF
--- a/config/wau_thresholds.yml
+++ b/config/wau_thresholds.yml
@@ -1,0 +1,8 @@
+personal: 0.30
+family: 0.55
+group: 0.70
+community: 0.80
+world: 0.90
+hysteresis:
+  up_margin: 0.03
+  down_margin: 0.05

--- a/src/kairo-lib/Cargo.toml
+++ b/src/kairo-lib/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 ed25519-dalek = "2"
 hex = "0.4"
 rand = "0.8"

--- a/src/kairo-lib/lib.rs
+++ b/src/kairo-lib/lib.rs
@@ -7,6 +7,8 @@ pub mod governance;
 pub mod packet;
 pub mod registry;
 pub mod resolvers;
+pub mod wau_config;
+pub mod mesh_scope_manager;
 
 // --- 構造体・型の再エクスポート ---
 pub use comm::{sign_message, Message};

--- a/src/kairo-lib/mesh_scope_manager.rs
+++ b/src/kairo-lib/mesh_scope_manager.rs
@@ -1,5 +1,7 @@
 //! mesh_scope_manager.rs
-//! Defines mesh Scopes and manages scope transitions.
+//! Manages mesh scope transitions based on WAU scores.
+
+use crate::wau_config::WauThresholds;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Scope {
@@ -10,18 +12,74 @@ pub enum Scope {
     World,
 }
 
-pub struct MeshScopeManager {}
-
-impl MeshScopeManager {
-    pub fn new() -> Self {
-        Self {}
-    }
-
-    pub fn set_scope(&self, _scope: Scope) {
-        // TODO: implement scope transition logic
-    }
+pub struct MeshScopeManager {
+    thresholds: WauThresholds,
+    current_scope: Scope,
 }
 
-// NOTE on recovery: A node flagged as 'black' (e.g., trust_score near 0.0) is demoted to Personal.
-// Recovery is not handled by this module automatically. It must be re-initiated through
-// successful Peer Reviews from other nodes, leading to a natural trust score increase.
+impl MeshScopeManager {
+    /// Creates a new manager from provided thresholds.
+    pub fn new(thresholds: WauThresholds) -> Self {
+        Self {
+            thresholds,
+            current_scope: Scope::Personal,
+        }
+    }
+
+    /// Returns the current scope.
+    pub fn current_scope(&self) -> Scope {
+        self.current_scope
+    }
+
+    /// Updates the current scope based on a WAU score applying hysteresis.
+    pub fn update_scope(&mut self, score: f32) {
+        let t = &self.thresholds;
+        let up = t.hysteresis.up_margin;
+        let down = t.hysteresis.down_margin;
+
+        use Scope::*;
+        self.current_scope = match self.current_scope {
+            Personal => {
+                if score >= t.family + up {
+                    Family
+                } else {
+                    Personal
+                }
+            }
+            Family => {
+                if score >= t.group + up {
+                    Group
+                } else if score < t.family - down {
+                    Personal
+                } else {
+                    Family
+                }
+            }
+            Group => {
+                if score >= t.community + up {
+                    Community
+                } else if score < t.group - down {
+                    Family
+                } else {
+                    Group
+                }
+            }
+            Community => {
+                if score >= t.world + up {
+                    World
+                } else if score < t.community - down {
+                    Group
+                } else {
+                    Community
+                }
+            }
+            World => {
+                if score < t.world - down {
+                    Community
+                } else {
+                    World
+                }
+            }
+        };
+    }
+}

--- a/src/kairo-lib/wau_config.rs
+++ b/src/kairo-lib/wau_config.rs
@@ -1,0 +1,26 @@
+//! Loads WAU thresholds from YAML.
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Hysteresis {
+    pub up_margin: f32,
+    pub down_margin: f32,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct WauThresholds {
+    pub personal: f32,
+    pub family: f32,
+    pub group: f32,
+    pub community: f32,
+    pub world: f32,
+    pub hysteresis: Hysteresis,
+}
+
+impl WauThresholds {
+    pub fn load_from(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let s = std::fs::read_to_string(path)?;
+        let v: Self = serde_yaml::from_str(&s)?;
+        Ok(v)
+    }
+}

--- a/tests/wau_config_test.rs
+++ b/tests/wau_config_test.rs
@@ -1,0 +1,2 @@
+#[test]
+fn load_wau_thresholds(){ let cfg=crate::wau_config::WauThresholds::load_from("config/wau_thresholds.yml").unwrap(); assert!(cfg.world>cfg.personal); }


### PR DESCRIPTION
## Summary
- load WAU thresholds and hysteresis margins from a YAML config
- drive mesh scope promotions/demotions using configurable thresholds
- add basic test to ensure WAU config parses

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68978b16b7708333900799d63a2e8251