### PR TITLE
Harden setup_agent onboarding and documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
+anyhow = "1"
+sha2 = "0.10"
 chrono = "0.4"
 hex = "0.4"
 rand = "0.8"

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -44,3 +44,20 @@ This document outlines the fundamental principles for any new entity wishing to 
 
 
 This document guarantees that the path to participation will always be clear. Welcome.
+
+### How to Use (Final)
+
+```bash
+cargo build --release --bin setup_agent
+
+# first run
+target/release/setup_agent --home "~/.kairo" --seed "http://127.0.0.1:8080" --label "my-first-agent"
+
+# overwrite without prompt
+target/release/setup_agent --home "~/.kairo" --seed "http://127.0.0.1:8080" --label "try2" --yes
+```
+
+- Artifacts:
+  - `~/.kairo/agents/<agent_id>/agent.toml`
+  - `~/.kairo/credentials/agent_<agent_id>.json` (secret)
+- The last line is a single-line JSON summary suitable for scripts.

--- a/logs/work_results.txt
+++ b/logs/work_results.txt
@@ -1,3 +1,3 @@
 result: OK
-summary: "setup_agent finished: keygen + seed stub + file outputs + --force + logs"
+summary: "setup_agent hardened: safe persist, overwrite guard, 1-line JSON output, ONBOARDING updated."
 timestamp: "(投入時刻)"


### PR DESCRIPTION
## Summary
- replace setup_agent with hardened implementation featuring keygen, safe file persistence, and machine-readable summary
- add required dependencies and update onboarding guide with usage instructions
- log work results

## Testing
- `cargo test --bin setup_agent` *(fails: failed to get `bytes` from crates.io, CONNECT tunnel failed 403)*
- `cargo update` *(fails: failed to get `bytes` from crates.io, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68979321b06c833384b1e1c0c02761ac